### PR TITLE
Implement CozyCommerce-inspired storefront routes and UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.44.4",
@@ -17,6 +18,8 @@
   },
   "devDependencies": {
     "@eslint/js": "^8.57.0",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^14.2.1",
     "@types/react": "^18.2.48",
     "@types/react-dom": "^18.2.21",
     "@vitejs/plugin-react": "^4.2.1",
@@ -25,9 +28,11 @@
     "eslint-plugin-react": "^7.34.0",
     "eslint-plugin-react-hooks": "^4.6.0",
     "globals": "^15.0.0",
+    "jsdom": "^24.0.0",
     "postcss": "^8.4.35",
     "tailwindcss": "^3.4.3",
     "typescript": "^5.4.2",
-    "vite": "^5.2.0"
+    "vite": "^5.2.0",
+    "vitest": "^1.5.3"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,119 +1,18 @@
-import { Link, NavLink, Outlet } from 'react-router-dom'
+import { Outlet } from 'react-router-dom'
+import CartDrawer from './components/CartDrawer'
+import NavigationBar from './components/NavigationBar'
 
-export function HomePage() {
+export default function AppLayout() {
   return (
-    <div className="mx-auto flex max-w-4xl flex-col gap-10 px-6 py-16">
-      <section className="space-y-6 text-center">
-        <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">
-          CozyCommerce Starter
-        </h1>
-        <p className="text-lg text-slate-300">
-          Jump start a Supabase enabled storefront with Vite, React Router, and Tailwind CSS.
-        </p>
-        <div className="flex flex-wrap justify-center gap-4">
-          <NavLink
-            to="/getting-started"
-            className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-300"
-          >
-            Explore the guide
-          </NavLink>
-          <a
-            href="https://supabase.com/"
-            target="_blank"
-            rel="noreferrer"
-            className="rounded-full border border-slate-700 px-6 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
-          >
-            Supabase docs
-          </a>
-        </div>
-      </section>
-      <section className="grid gap-4 rounded-3xl border border-slate-800 bg-slate-900/60 p-8 text-left shadow-xl shadow-slate-950/40 sm:grid-cols-2">
-        <Feature
-          title="Realtime data"
-          description="Manage products, inventory, and orders with Supabase tables and subscriptions."
-        />
-        <Feature
-          title="Beautiful UI"
-          description="Tailwind CSS primitives let you recreate CozyCommerce screens quickly."
-        />
-        <Feature
-          title="Client routing"
-          description="React Router keeps navigation snappy and URL driven."
-        />
-        <Feature
-          title="TypeScript first"
-          description="The toolkit ships with strict TypeScript settings and path aliases."
-        />
-      </section>
-    </div>
-  )
-}
-
-export function GettingStartedPage() {
-  return (
-    <div className="mx-auto max-w-3xl space-y-6 px-6 py-16">
-      <h2 className="text-3xl font-semibold text-white">Getting started</h2>
-      <ol className="space-y-4 text-slate-300">
-        <li>
-          <strong className="text-white">1. Configure Supabase:</strong> Copy <code>.env.example</code> to <code>.env.local</code> and
-          provide your project URL and anon key.
-        </li>
-        <li>
-          <strong className="text-white">2. Run the dev server:</strong> Install dependencies with <code>npm install</code> then run <code>npm run dev</code>.
-        </li>
-        <li>
-          <strong className="text-white">3. Build your flows:</strong> Use the Supabase client exported from <code>src/supabaseClient.ts</code>
-          to fetch data, manage auth, and listen for realtime updates.
-        </li>
-      </ol>
-    </div>
-  )
-}
-
-function Feature({ title, description }: { title: string; description: string }) {
-  return (
-    <div className="rounded-2xl border border-slate-800/80 bg-slate-900/50 p-5">
-      <h3 className="text-lg font-semibold text-white">{title}</h3>
-      <p className="mt-2 text-sm text-slate-300">{description}</p>
-    </div>
-  )
-}
-
-export default function App() {
-  return (
-    <div className="min-h-screen bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
-      <header className="border-b border-slate-800/80 bg-slate-950/70 backdrop-blur">
-        <nav className="mx-auto flex max-w-5xl items-center justify-between px-6 py-4">
-          <Link to="/" className="text-lg font-bold text-white">
-            CozyCommerce
-          </Link>
-          <div className="flex items-center gap-6 text-sm font-medium text-slate-300">
-            <NavLink
-              to="/"
-              end
-              className={({ isActive }) =>
-                `transition hover:text-white ${isActive ? 'text-white' : ''}`
-              }
-            >
-              Home
-            </NavLink>
-            <NavLink
-              to="/getting-started"
-              className={({ isActive }) =>
-                `transition hover:text-white ${isActive ? 'text-white' : ''}`
-              }
-            >
-              Getting started
-            </NavLink>
-          </div>
-        </nav>
-      </header>
-      <main>
+    <div className="flex min-h-screen flex-col bg-slate-950 text-slate-100">
+      <NavigationBar />
+      <main className="flex-1 bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950">
         <Outlet />
       </main>
-      <footer className="border-t border-slate-800/80 bg-slate-950/70 py-6 text-center text-xs text-slate-500">
-        Built with Vite, React, Tailwind CSS, and Supabase
+      <footer className="border-t border-slate-800/80 bg-slate-950/70 py-8 text-center text-xs text-slate-500">
+        Crafted with Supabase, React Router, and Tailwind CSS — inspired by CozyCommerce
       </footer>
+      <CartDrawer />
     </div>
   )
 }

--- a/src/components/CartDrawer.tsx
+++ b/src/components/CartDrawer.tsx
@@ -1,0 +1,128 @@
+import { Link } from 'react-router-dom'
+import { useStore } from '../context/StoreContext'
+
+export default function CartDrawer() {
+  const {
+    cart: { items, subtotal, isOpen, close, updateItemQuantity, removeItem },
+  } = useStore()
+
+  return (
+    <div
+      className={`pointer-events-none fixed inset-0 z-50 flex justify-end transition ${
+        isOpen ? 'pointer-events-auto opacity-100' : 'opacity-0'
+      }`}
+      aria-hidden={!isOpen}
+    >
+      <div className="flex-1 bg-slate-950/60 backdrop-blur" onClick={close} />
+      <aside
+        className={`flex h-full w-full max-w-md flex-col border-l border-slate-800/70 bg-slate-950 transition-transform duration-300 ${
+          isOpen ? 'translate-x-0' : 'translate-x-full'
+        }`}
+        aria-label="Shopping cart"
+      >
+        <header className="flex items-center justify-between border-b border-slate-800/70 px-6 py-5">
+          <div>
+            <h2 className="text-lg font-semibold text-white">Your cart</h2>
+            <p className="text-xs text-slate-400">{items.length} {items.length === 1 ? 'item' : 'items'}</p>
+          </div>
+          <button
+            type="button"
+            onClick={close}
+            className="rounded-full border border-slate-800/70 p-2 text-slate-300 transition hover:border-slate-600 hover:text-white"
+          >
+            Close
+          </button>
+        </header>
+        <div className="flex-1 overflow-y-auto px-6 py-4">
+          {!items.length && (
+            <p className="text-sm text-slate-400">Your cart is empty. Add products from the shop to get started.</p>
+          )}
+          <ul className="space-y-6">
+            {items.map((item) => (
+              <li key={item.id} className="flex gap-4">
+                <div className="h-24 w-24 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/80">
+                  {item.product.gallery?.[0] ? (
+                    <img
+                      src={item.product.gallery[0]}
+                      alt={item.product.name}
+                      className="h-full w-full object-cover"
+                    />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-xs text-slate-500">No image</div>
+                  )}
+                </div>
+                <div className="flex flex-1 flex-col gap-2">
+                  <div className="flex items-start justify-between gap-2">
+                    <div>
+                      <p className="text-sm font-semibold text-white">{item.product.name}</p>
+                      <p className="text-xs text-slate-400">{item.product.category ?? 'General'}</p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeItem(item.id)}
+                      className="text-xs font-medium text-slate-400 transition hover:text-emerald-300"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => updateItemQuantity(item.id, Math.max(1, item.quantity - 1))}
+                        className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-800/60 text-sm text-slate-300 transition hover:border-slate-600 hover:text-white"
+                        aria-label="Decrease quantity"
+                      >
+                        −
+                      </button>
+                      <span className="w-8 text-center text-sm text-white">{item.quantity}</span>
+                      <button
+                        type="button"
+                        onClick={() => updateItemQuantity(item.id, item.quantity + 1)}
+                        className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-800/60 text-sm text-slate-300 transition hover:border-slate-600 hover:text-white"
+                        aria-label="Increase quantity"
+                      >
+                        +
+                      </button>
+                    </div>
+                    <span className="text-sm font-semibold text-emerald-300">
+                      {new Intl.NumberFormat('en-US', {
+                        style: 'currency',
+                        currency: item.product.currency ?? 'USD',
+                      }).format(item.unitPrice * item.quantity)}
+                    </span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <footer className="border-t border-slate-800/70 p-6">
+          <div className="flex items-center justify-between text-sm">
+            <span className="text-slate-400">Subtotal</span>
+            <span className="text-lg font-semibold text-white">
+              {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(subtotal)}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-slate-500">Shipping and taxes calculated at checkout.</p>
+          <div className="mt-5 flex flex-col gap-3">
+            <Link
+              to="/checkout"
+              onClick={close}
+              className="rounded-full bg-emerald-400 px-4 py-3 text-center text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            >
+              Proceed to checkout
+            </Link>
+            <Link
+              to="/cart"
+              onClick={close}
+              className="rounded-full border border-slate-700 px-4 py-3 text-center text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
+            >
+              View cart details
+            </Link>
+          </div>
+        </footer>
+      </aside>
+    </div>
+  )
+}

--- a/src/components/HeroBanner.tsx
+++ b/src/components/HeroBanner.tsx
@@ -1,0 +1,65 @@
+import { Link } from 'react-router-dom'
+
+interface HeroBannerProps {
+  eyebrow?: string
+  title: string
+  description: string
+  backgroundImage?: string
+  primaryCta: { label: string; to: string }
+  secondaryCta?: { label: string; to: string }
+  align?: 'left' | 'center'
+}
+
+export default function HeroBanner({
+  eyebrow,
+  title,
+  description,
+  backgroundImage,
+  primaryCta,
+  secondaryCta,
+  align = 'center',
+}: HeroBannerProps) {
+  const alignmentClasses =
+    align === 'left'
+      ? 'items-start text-left sm:items-start sm:text-left'
+      : 'items-center text-center sm:items-center sm:text-center'
+
+  return (
+    <section className="relative overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/80 p-10 shadow-2xl shadow-emerald-500/10 sm:p-16">
+      {backgroundImage && (
+        <div
+          className="pointer-events-none absolute inset-0 opacity-40"
+          aria-hidden
+          style={{
+            backgroundImage: `linear-gradient(120deg, rgba(15, 23, 42, 0.95), rgba(15, 23, 42, 0.7)), url(${backgroundImage})`,
+            backgroundSize: 'cover',
+            backgroundPosition: 'center',
+          }}
+        />
+      )}
+      <div className={`relative z-10 mx-auto flex max-w-3xl flex-col gap-6 ${alignmentClasses}`}>
+        {eyebrow && (
+          <p className="text-sm font-semibold uppercase tracking-[0.2em] text-emerald-300">{eyebrow}</p>
+        )}
+        <h1 className="text-4xl font-bold tracking-tight text-white sm:text-5xl">{title}</h1>
+        <p className="text-lg text-slate-300 sm:text-xl">{description}</p>
+        <div className={`flex flex-wrap gap-4 ${align === 'left' ? 'justify-start' : 'justify-center'}`}>
+          <Link
+            to={primaryCta.to}
+            className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 shadow-lg shadow-emerald-500/30 transition hover:bg-emerald-300"
+          >
+            {primaryCta.label}
+          </Link>
+          {secondaryCta && (
+            <Link
+              to={secondaryCta.to}
+              className="rounded-full border border-slate-700 px-6 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
+            >
+              {secondaryCta.label}
+            </Link>
+          )}
+        </div>
+      </div>
+    </section>
+  )
+}

--- a/src/components/NavigationBar.tsx
+++ b/src/components/NavigationBar.tsx
@@ -1,0 +1,135 @@
+import { useState } from 'react'
+import { Link, NavLink } from 'react-router-dom'
+import { useStore } from '../context/StoreContext'
+import { useBreakpoint } from '../hooks/useBreakpoint'
+
+const navItems = [
+  { to: '/', label: 'Home' },
+  { to: '/products', label: 'Shop' },
+  { to: '/checkout', label: 'Checkout' },
+  { to: '/account', label: 'Account' },
+]
+
+function CartIcon() {
+  return (
+    <svg aria-hidden className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+      <path d="M2.25 3h1.386c.51 0 .955.343 1.087.835l.383 1.437m0 0 1.35 5.062a2.25 2.25 0 0 0 2.183 1.666h8.964a2.25 2.25 0 0 0 2.183-1.666l1.218-4.569a1.125 1.125 0 0 0-1.087-1.415H6.766m0 0-1.46-5.477m4.71 18.102a1.125 1.125 0 1 1-2.25 0 1.125 1.125 0 0 1 2.25 0Zm9 0a1.125 1.125 0 1 1-2.25 0 1.125 1.125 0 0 1 2.25 0Z" />
+    </svg>
+  )
+}
+
+function UserIcon() {
+  return (
+    <svg aria-hidden className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+      <path d="M15.75 7.5a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.5 20.118a9.028 9.028 0 0 1 15 0" />
+    </svg>
+  )
+}
+
+function MenuIcon() {
+  return (
+    <svg aria-hidden className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+      <path d="M3.75 6.75h16.5M3.75 12h16.5m-16.5 5.25h16.5" />
+    </svg>
+  )
+}
+
+function CloseIcon() {
+  return (
+    <svg aria-hidden className="h-6 w-6" fill="none" stroke="currentColor" strokeWidth="1.5" viewBox="0 0 24 24">
+      <path d="M6 18 18 6M6 6l12 12" />
+    </svg>
+  )
+}
+
+export default function NavigationBar() {
+  const [isMobileMenuOpen, setMobileMenuOpen] = useState(false)
+  const isDesktop = useBreakpoint('md')
+  const {
+    cart: { count, open },
+  } = useStore()
+
+  const toggleMenu = () => setMobileMenuOpen((openState) => !openState)
+  const closeMenu = () => setMobileMenuOpen(false)
+
+  const renderNavItems = (orientation: 'row' | 'column') => (
+    <div
+      className={
+        orientation === 'row'
+          ? 'flex items-center gap-2'
+          : 'flex flex-col gap-3 rounded-2xl border border-slate-800/70 bg-slate-900/60 p-4'
+      }
+    >
+      {navItems.map((item) => (
+        <NavLink
+          key={item.to}
+          to={item.to}
+          className={({ isActive }) =>
+            `rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+              isActive
+                ? 'bg-emerald-400 text-slate-950 shadow-lg shadow-emerald-500/30'
+                : 'text-slate-300 hover:text-white'
+            }`
+          }
+          onClick={closeMenu}
+          end={item.to === '/'}
+        >
+          {item.label}
+        </NavLink>
+      ))}
+    </div>
+  )
+
+  return (
+    <header className="border-b border-slate-800/60 bg-slate-950/70 backdrop-blur">
+      <div className="mx-auto flex max-w-6xl items-center justify-between px-4 py-5 md:px-6">
+        <div className="flex items-center gap-3">
+          {!isDesktop && (
+            <button
+              type="button"
+              onClick={toggleMenu}
+              className="rounded-full border border-slate-800/80 bg-slate-900/70 p-2 text-slate-200 transition hover:border-slate-600 hover:text-white"
+              aria-label={isMobileMenuOpen ? 'Close navigation' : 'Open navigation'}
+            >
+              {isMobileMenuOpen ? <CloseIcon /> : <MenuIcon />}
+            </button>
+          )}
+          <Link to="/" className="text-lg font-semibold tracking-tight text-white">
+            CozyCommerce
+          </Link>
+        </div>
+
+        {isDesktop && renderNavItems('row')}
+
+        <div className="flex items-center gap-3">
+          <NavLink
+            to="/account"
+            className="rounded-full border border-transparent bg-slate-900/60 p-2 text-slate-200 transition hover:border-slate-700 hover:text-white"
+            aria-label="Account"
+          >
+            <UserIcon />
+          </NavLink>
+          <button
+            type="button"
+            onClick={() => open()}
+            className="relative rounded-full border border-transparent bg-emerald-400/20 p-2 text-emerald-300 transition hover:bg-emerald-400/30 hover:text-emerald-200"
+            aria-label="Open cart"
+          >
+            <CartIcon />
+            {count > 0 && (
+              <span className="absolute -right-1 -top-1 flex h-5 min-w-[1.25rem] items-center justify-center rounded-full bg-emerald-400 px-1 text-xs font-semibold text-slate-950">
+                {count}
+              </span>
+            )}
+          </button>
+        </div>
+      </div>
+
+      {!isDesktop && isMobileMenuOpen && (
+        <div className="border-t border-slate-800/60 bg-slate-950/90 px-4 py-4 md:hidden">
+          {renderNavItems('column')}
+        </div>
+      )}
+    </header>
+  )
+}

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,0 +1,71 @@
+import { Link } from 'react-router-dom'
+import { Product } from '../context/StoreContext'
+import { useStore } from '../context/StoreContext'
+
+interface ProductCardProps {
+  product: Product
+  showDescription?: boolean
+}
+
+export default function ProductCard({ product, showDescription = false }: ProductCardProps) {
+  const {
+    cart: { addItem },
+  } = useStore()
+
+  const primaryImage = product.gallery?.[0] ?? product.image_url
+  const priceLabel = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: product.currency ?? 'USD',
+  }).format(product.price ?? 0)
+
+  return (
+    <article className="group flex flex-col overflow-hidden rounded-3xl border border-slate-800/70 bg-slate-900/60 shadow-lg transition hover:-translate-y-1 hover:shadow-emerald-500/20">
+      <Link to={`/products/${product.slug}`} className="relative block aspect-[4/5] overflow-hidden">
+        {primaryImage ? (
+          <img
+            src={primaryImage}
+            alt={product.name}
+            className="h-full w-full object-cover transition duration-500 group-hover:scale-105"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center bg-slate-900">
+            <span className="text-sm text-slate-500">Image coming soon</span>
+          </div>
+        )}
+        {(product.tags ?? []).includes('new') && (
+          <span className="absolute left-4 top-4 rounded-full bg-emerald-400/90 px-3 py-1 text-xs font-semibold uppercase tracking-widest text-slate-950">
+            New
+          </span>
+        )}
+      </Link>
+      <div className="flex flex-1 flex-col gap-4 p-6">
+        <div className="flex flex-col gap-2">
+          <div className="flex items-center justify-between">
+            <h3 className="text-lg font-semibold text-white">
+              <Link to={`/products/${product.slug}`} className="transition hover:text-emerald-300">
+                {product.name}
+              </Link>
+            </h3>
+            <span className="text-sm font-semibold text-emerald-300">{priceLabel}</span>
+          </div>
+          {product.inventory_status && (
+            <span className="text-xs font-medium uppercase tracking-widest text-slate-400">
+              {product.inventory_status}
+            </span>
+          )}
+          {showDescription && product.description && (
+            <p className="text-sm text-slate-400">{product.description}</p>
+          )}
+        </div>
+        <button
+          type="button"
+          onClick={() => addItem(product, 1)}
+          className="rounded-full bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+        >
+          Add to cart
+        </button>
+      </div>
+    </article>
+  )
+}

--- a/src/components/ProductCarousel.tsx
+++ b/src/components/ProductCarousel.tsx
@@ -1,0 +1,42 @@
+import ProductCard from './ProductCard'
+import { Product } from '../context/StoreContext'
+import { useBreakpoint } from '../hooks/useBreakpoint'
+
+interface ProductCarouselProps {
+  title: string
+  subtitle?: string
+  products: Product[]
+}
+
+export default function ProductCarousel({ title, subtitle, products }: ProductCarouselProps) {
+  const isDesktop = useBreakpoint('lg')
+
+  if (!products.length) {
+    return null
+  }
+
+  return (
+    <section className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h2 className="text-2xl font-semibold text-white sm:text-3xl">{title}</h2>
+          {subtitle && <p className="text-sm text-slate-400">{subtitle}</p>}
+        </div>
+      </div>
+      <div
+        data-testid="product-carousel-track"
+        className="flex gap-6 overflow-x-auto pb-4 [scrollbar-width:none] [-ms-overflow-style:none]"
+        style={{ scrollSnapType: isDesktop ? 'none' : 'x mandatory' }}
+      >
+        {products.map((product) => (
+          <div
+            key={product.id}
+            className="w-72 shrink-0 scroll-mx-6 scroll-smooth snap-start sm:w-80 lg:w-72 xl:w-80"
+          >
+            <ProductCard product={product} />
+          </div>
+        ))}
+      </div>
+    </section>
+  )
+}

--- a/src/components/__tests__/responsiveLayout.test.tsx
+++ b/src/components/__tests__/responsiveLayout.test.tsx
@@ -1,0 +1,75 @@
+import type { ReactElement } from 'react'
+import { render, screen } from '@testing-library/react'
+import NavigationBar from '../NavigationBar'
+import ProductCarousel from '../ProductCarousel'
+import { StoreProvider, type Product } from '../../context/StoreContext'
+
+declare global {
+  // eslint-disable-next-line no-var
+  var setScreenWidth: (width: number) => void
+}
+
+function renderWithProvider(ui: ReactElement, products: Product[] = [createProduct()]) {
+  return render(
+    <StoreProvider supabaseClient={null} disableInitialFetch initialState={{ products }}>
+      {ui}
+    </StoreProvider>
+  )
+}
+
+function createProduct(overrides: Partial<Product> = {}): Product {
+  return {
+    id: 'prod_1',
+    name: 'Ambient Glow Lamp',
+    slug: 'ambient-glow-lamp',
+    price: 189,
+    currency: 'USD',
+    description: 'A warm light for cozy evenings.',
+    gallery: ['https://images.unsplash.com/photo-1505691723518-36a5ac3be353?auto=format&fit=crop&w=400&q=80'],
+    category: 'Lighting',
+    tags: ['featured'],
+    featured: true,
+    variants: [],
+    ...overrides,
+  }
+}
+
+describe('Responsive layout primitives', () => {
+  beforeEach(() => {
+    globalThis.setScreenWidth(1024)
+  })
+
+  it('renders hamburger navigation on small screens', () => {
+    globalThis.setScreenWidth(480)
+    renderWithProvider(<NavigationBar />)
+    expect(screen.getByLabelText('Open navigation')).toBeInTheDocument()
+    expect(screen.queryByText('Shop')).not.toBeInTheDocument()
+  })
+
+  it('renders inline navigation links on desktop screens', () => {
+    globalThis.setScreenWidth(1280)
+    renderWithProvider(<NavigationBar />)
+    expect(screen.getByText('Shop')).toBeInTheDocument()
+    expect(screen.queryByLabelText('Open navigation')).not.toBeInTheDocument()
+  })
+
+  it('enables scroll snapping for product carousel on mobile', () => {
+    globalThis.setScreenWidth(600)
+    const product = createProduct({ id: 'prod_mobile' })
+    const { getByTestId } = renderWithProvider(
+      <ProductCarousel title="Featured" products={[product]} />,
+      [product]
+    )
+    expect(getByTestId('product-carousel-track')).toHaveStyle('scroll-snap-type: x mandatory')
+  })
+
+  it('disables scroll snapping for carousel on desktop', () => {
+    globalThis.setScreenWidth(1400)
+    const product = createProduct({ id: 'prod_desktop' })
+    const { getByTestId } = renderWithProvider(
+      <ProductCarousel title="Featured" products={[product]} />,
+      [product]
+    )
+    expect(getByTestId('product-carousel-track')).toHaveStyle('scroll-snap-type: none')
+  })
+})

--- a/src/components/checkout/CheckoutForms.tsx
+++ b/src/components/checkout/CheckoutForms.tsx
@@ -1,0 +1,333 @@
+import { FormEvent, ReactNode } from 'react'
+import { Link } from 'react-router-dom'
+import { useStore } from '../../context/StoreContext'
+
+export default function CheckoutForms() {
+  const {
+    cart,
+    checkout: {
+      step,
+      shipping,
+      payment,
+      status,
+      error,
+      updatePayment,
+      updateShipping,
+      goToStep,
+      placeOrder,
+    },
+  } = useStore()
+
+  const handleShippingSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    goToStep('payment')
+  }
+
+  const handlePaymentSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    goToStep('review')
+  }
+
+  const handlePlaceOrder = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    await placeOrder()
+  }
+
+  return (
+    <div className="mt-8">
+      {error && (
+        <div className="mb-6 rounded-2xl border border-rose-500/60 bg-rose-500/10 px-4 py-3 text-sm text-rose-200">
+          {error}
+        </div>
+      )}
+      {step === 'shipping' && (
+        <form
+          className="space-y-6 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6"
+          onSubmit={handleShippingSubmit}
+        >
+          <div className="grid gap-4 sm:grid-cols-2">
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              Full name
+              <input
+                required
+                type="text"
+                value={shipping.name}
+                onChange={(event) => updateShipping({ name: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              Email
+              <input
+                required
+                type="email"
+                value={shipping.email}
+                onChange={(event) => updateShipping({ email: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              Phone number
+              <input
+                required
+                type="tel"
+                value={shipping.phone}
+                onChange={(event) => updateShipping({ phone: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              Country
+              <input
+                required
+                type="text"
+                value={shipping.country}
+                onChange={(event) => updateShipping({ country: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300 sm:col-span-2">
+              Address line 1
+              <input
+                required
+                type="text"
+                value={shipping.address1}
+                onChange={(event) => updateShipping({ address1: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300 sm:col-span-2">
+              Address line 2
+              <input
+                type="text"
+                value={shipping.address2 ?? ''}
+                onChange={(event) => updateShipping({ address2: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              City
+              <input
+                required
+                type="text"
+                value={shipping.city}
+                onChange={(event) => updateShipping({ city: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+            <label className="flex flex-col gap-2 text-sm text-slate-300">
+              Postal code
+              <input
+                required
+                type="text"
+                value={shipping.postalCode}
+                onChange={(event) => updateShipping({ postalCode: event.target.value })}
+                className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              />
+            </label>
+          </div>
+          <div className="flex justify-end">
+            <button
+              type="submit"
+              className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            >
+              Continue to payment
+            </button>
+          </div>
+        </form>
+      )}
+
+      {step === 'payment' && (
+        <form
+          className="space-y-6 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6"
+          onSubmit={handlePaymentSubmit}
+        >
+          <fieldset className="grid gap-4 sm:grid-cols-3">
+            <legend className="sr-only">Payment method</legend>
+            {['card', 'paypal', 'apple-pay'].map((method) => (
+              <label
+                key={method}
+                className={`flex cursor-pointer flex-col gap-2 rounded-2xl border px-4 py-3 text-sm transition ${
+                  payment.method === method
+                    ? 'border-emerald-400/80 bg-emerald-400/10 text-emerald-200'
+                    : 'border-slate-800/60 bg-slate-900/80 text-slate-300 hover:border-slate-700'
+                }`}
+              >
+                <input
+                  type="radio"
+                  name="payment-method"
+                  value={method}
+                  checked={payment.method === method}
+                  onChange={() => updatePayment({ method: method as typeof payment.method })}
+                  className="sr-only"
+                />
+                <span className="font-semibold capitalize">{method.replace('-', ' ')}</span>
+                <span className="text-xs text-slate-400">
+                  {method === 'card' && 'Pay securely using your credit card.'}
+                  {method === 'paypal' && 'You will be redirected to PayPal to complete payment.'}
+                  {method === 'apple-pay' && 'Pay quickly with Apple Pay supported devices.'}
+                </span>
+              </label>
+            ))}
+          </fieldset>
+
+          {payment.method === 'card' && (
+            <div className="grid gap-4 sm:grid-cols-2">
+              <label className="flex flex-col gap-2 text-sm text-slate-300 sm:col-span-2">
+                Cardholder name
+                <input
+                  required
+                  type="text"
+                  value={payment.cardholder}
+                  onChange={(event) => updatePayment({ cardholder: event.target.value })}
+                  className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm text-slate-300">
+                Card number
+                <input
+                  required
+                  inputMode="numeric"
+                  value={payment.cardNumber}
+                  onChange={(event) => updatePayment({ cardNumber: event.target.value })}
+                  className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm text-slate-300">
+                Expiry
+                <input
+                  required
+                  placeholder="MM/YY"
+                  value={payment.expiry}
+                  onChange={(event) => updatePayment({ expiry: event.target.value })}
+                  className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+                />
+              </label>
+              <label className="flex flex-col gap-2 text-sm text-slate-300">
+                CVC
+                <input
+                  required
+                  type="password"
+                  value={payment.cvc}
+                  onChange={(event) => updatePayment({ cvc: event.target.value })}
+                  className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+                />
+              </label>
+            </div>
+          )}
+
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => goToStep('shipping')}
+              className="rounded-full border border-slate-700 px-6 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
+            >
+              Back to shipping
+            </button>
+            <button
+              type="submit"
+              className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            >
+              Review order
+            </button>
+          </div>
+        </form>
+      )}
+
+      {step === 'review' && (
+        <form
+          className="space-y-6 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6"
+          onSubmit={handlePlaceOrder}
+        >
+          <div className="space-y-4">
+            <div>
+              <h3 className="text-lg font-semibold text-white">Shipping to</h3>
+              <p className="text-sm text-slate-300">
+                {shipping.name} · {shipping.address1}, {shipping.city} {shipping.postalCode}
+              </p>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-white">Payment method</h3>
+              <p className="text-sm text-slate-300 capitalize">{payment.method.replace('-', ' ')}</p>
+            </div>
+            <div>
+              <h3 className="text-lg font-semibold text-white">Order summary</h3>
+              <ul className="space-y-3">
+                {cart.items.map((item) => (
+                  <li key={item.id} className="flex justify-between text-sm text-slate-300">
+                    <span>
+                      {item.product.name} × {item.quantity}
+                    </span>
+                    <span>
+                      {new Intl.NumberFormat('en-US', {
+                        style: 'currency',
+                        currency: item.product.currency ?? 'USD',
+                      }).format(item.unitPrice * item.quantity)}
+                    </span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+            <div className="flex justify-between border-t border-slate-800/60 pt-4 text-sm text-white">
+              <span>Total</span>
+              <span>
+                {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(cart.subtotal)}
+              </span>
+            </div>
+          </div>
+          <div className="flex justify-between">
+            <button
+              type="button"
+              onClick={() => goToStep('payment')}
+              className="rounded-full border border-slate-700 px-6 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
+            >
+              Back to payment
+            </button>
+            <button
+              type="submit"
+              disabled={status === 'submitting'}
+              className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-70"
+            >
+              {status === 'submitting' ? 'Placing order…' : 'Place order'}
+            </button>
+          </div>
+        </form>
+      )}
+
+      {step === 'confirmation' && (
+        <div className="space-y-4 rounded-3xl border border-emerald-500/60 bg-emerald-500/10 p-6 text-center">
+          <h3 className="text-2xl font-semibold text-white">Thank you for your order!</h3>
+          <p className="text-sm text-emerald-100">
+            A confirmation email is on its way. You can keep track of your orders from the account page.
+          </p>
+          <div className="flex justify-center gap-4">
+            <button
+              type="button"
+              onClick={() => goToStep('shipping')}
+              className="rounded-full border border-emerald-300 px-6 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-400/20"
+            >
+              Start a new order
+            </button>
+            <LinkButton to="/account">View orders</LinkButton>
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}
+
+interface LinkButtonProps {
+  to: string
+  children: ReactNode
+}
+
+function LinkButton({ to, children }: LinkButtonProps) {
+  return (
+    <Link
+      to={to}
+      className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+    >
+      {children}
+    </Link>
+  )
+}

--- a/src/components/checkout/CheckoutStepper.tsx
+++ b/src/components/checkout/CheckoutStepper.tsx
@@ -1,0 +1,48 @@
+import { CheckoutStep } from '../../context/StoreContext'
+
+const steps: { id: CheckoutStep; label: string }[] = [
+  { id: 'shipping', label: 'Shipping' },
+  { id: 'payment', label: 'Payment' },
+  { id: 'review', label: 'Review' },
+  { id: 'confirmation', label: 'Confirmation' },
+]
+
+interface CheckoutStepperProps {
+  currentStep: CheckoutStep
+  onStepChange?: (step: CheckoutStep) => void
+}
+
+export default function CheckoutStepper({ currentStep, onStepChange }: CheckoutStepperProps) {
+  const currentIndex = steps.findIndex((step) => step.id === currentStep)
+
+  return (
+    <nav aria-label="Checkout steps" className="flex flex-col gap-4">
+      <ol className="grid grid-cols-2 gap-4 sm:grid-cols-4">
+        {steps.map((step, index) => {
+          const isComplete = index < currentIndex
+          const isActive = index === currentIndex
+          return (
+            <li key={step.id}>
+              <button
+                type="button"
+                onClick={() => onStepChange?.(step.id)}
+                className={`flex w-full flex-col items-center gap-2 rounded-2xl border px-4 py-3 text-sm transition ${
+                  isActive
+                    ? 'border-emerald-400/80 bg-emerald-400/10 text-emerald-200'
+                    : isComplete
+                    ? 'border-slate-700 bg-slate-900/70 text-slate-200'
+                    : 'border-slate-800/60 bg-slate-950 text-slate-400 hover:border-slate-700'
+                }`}
+              >
+                <span className="flex h-8 w-8 items-center justify-center rounded-full border border-current text-xs font-semibold uppercase tracking-widest">
+                  {index + 1}
+                </span>
+                <span>{step.label}</span>
+              </button>
+            </li>
+          )
+        })}
+      </ol>
+    </nav>
+  )
+}

--- a/src/context/StoreContext.tsx
+++ b/src/context/StoreContext.tsx
@@ -1,0 +1,879 @@
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+  type ReactNode,
+} from 'react'
+import type { SupabaseClient } from '@supabase/supabase-js'
+import { supabase as defaultSupabase } from '../supabaseClient'
+
+export interface ProductVariant {
+  id: string
+  name: string
+  price?: number
+  sku?: string
+  stock?: number | null
+  option_values?: Record<string, string>
+}
+
+export interface Product {
+  id: string
+  name: string
+  slug: string
+  price: number
+  currency?: string
+  description?: string
+  image_url?: string | null
+  gallery?: string[]
+  category?: string | null
+  tags?: string[] | null
+  created_at?: string
+  rating?: number | null
+  featured?: boolean
+  inventory_status?: string | null
+  variants?: ProductVariant[] | null
+  metadata?: Record<string, unknown> | null
+}
+
+export interface CatalogFilters {
+  searchTerm: string
+  category: string | 'all'
+  priceRange: [number, number]
+  sort: 'featured' | 'price-asc' | 'price-desc' | 'newest'
+  tags: string[]
+}
+
+export interface CartItem {
+  id: string
+  productId: string
+  variantId?: string
+  quantity: number
+  unitPrice: number
+  product: Product
+}
+
+export type CheckoutStep = 'cart' | 'shipping' | 'payment' | 'review' | 'confirmation'
+
+export interface ShippingDetails {
+  name: string
+  email: string
+  phone: string
+  address1: string
+  address2?: string
+  city: string
+  state?: string
+  postalCode: string
+  country: string
+}
+
+export interface PaymentDetails {
+  method: 'card' | 'paypal' | 'apple-pay'
+  cardholder: string
+  cardNumber: string
+  expiry: string
+  cvc: string
+}
+
+export interface OrderSummary {
+  id: string
+  status: string
+  total: number
+  currency: string
+  created_at: string
+  items: CartItem[]
+}
+
+export interface Profile {
+  id: string
+  email?: string
+  full_name?: string
+  avatar_url?: string | null
+}
+
+interface CatalogState {
+  products: Product[]
+  productCache: Record<string, Product>
+  loading: boolean
+  error?: string
+}
+
+interface CartState {
+  items: CartItem[]
+  isOpen: boolean
+}
+
+interface CheckoutState {
+  step: CheckoutStep
+  shipping: ShippingDetails
+  payment: PaymentDetails
+  lastOrder?: OrderSummary
+  status: 'idle' | 'submitting' | 'success' | 'error'
+  error?: string
+}
+
+interface AccountState {
+  profile?: Profile
+  loading: boolean
+  error?: string
+  orders: OrderSummary[]
+}
+
+interface StoreContextValue {
+  catalog: {
+    products: Product[]
+    featuredProducts: Product[]
+    filteredProducts: Product[]
+    categories: string[]
+    filters: CatalogFilters
+    loading: boolean
+    error?: string
+    refresh: () => Promise<void>
+    setFilters: (filters: Partial<CatalogFilters>) => void
+    fetchProductBySlug: (slug: string) => Promise<Product | null>
+  }
+  cart: {
+    items: CartItem[]
+    count: number
+    subtotal: number
+    isOpen: boolean
+    addItem: (product: Product, quantity?: number, variantId?: string) => void
+    updateItemQuantity: (id: string, quantity: number) => void
+    removeItem: (id: string) => void
+    clear: () => void
+    open: () => void
+    close: () => void
+    toggle: () => void
+  }
+  checkout: {
+    step: CheckoutStep
+    shipping: ShippingDetails
+    payment: PaymentDetails
+    lastOrder?: OrderSummary
+    status: 'idle' | 'submitting' | 'success' | 'error'
+    error?: string
+    goToStep: (step: CheckoutStep) => void
+    updateShipping: (details: Partial<ShippingDetails>) => void
+    updatePayment: (details: Partial<PaymentDetails>) => void
+    placeOrder: () => Promise<void>
+    reset: () => void
+  }
+  account: {
+    profile?: Profile
+    loading: boolean
+    error?: string
+    orders: OrderSummary[]
+    refreshOrders: () => Promise<void>
+    signInWithOtp: (email: string) => Promise<void>
+    signOut: () => Promise<void>
+  }
+}
+
+interface StoreProviderProps {
+  children: ReactNode
+  supabaseClient?: SupabaseClient | null
+  initialState?: {
+    products?: Product[]
+    cartItems?: CartItem[]
+    profile?: Profile
+    orders?: OrderSummary[]
+  }
+  disableInitialFetch?: boolean
+}
+
+const defaultFilters: CatalogFilters = {
+  searchTerm: '',
+  category: 'all',
+  priceRange: [0, 2000],
+  sort: 'featured',
+  tags: [],
+}
+
+const emptyShipping: ShippingDetails = {
+  name: '',
+  email: '',
+  phone: '',
+  address1: '',
+  address2: '',
+  city: '',
+  state: '',
+  postalCode: '',
+  country: '',
+}
+
+const emptyPayment: PaymentDetails = {
+  method: 'card',
+  cardholder: '',
+  cardNumber: '',
+  expiry: '',
+  cvc: '',
+}
+
+const StoreContext = createContext<StoreContextValue | null>(null)
+
+function applyCatalogFilters(products: Product[], filters: CatalogFilters) {
+  const [minPrice, maxPrice] = filters.priceRange
+  let result = products.filter((product) => {
+    const price = product.price ?? 0
+    const matchesCategory = filters.category === 'all' || product.category === filters.category
+    const matchesSearch = filters.searchTerm
+      ? product.name.toLowerCase().includes(filters.searchTerm.toLowerCase()) ||
+        (product.description ?? '').toLowerCase().includes(filters.searchTerm.toLowerCase())
+      : true
+    const matchesTags = filters.tags.length
+      ? (product.tags ?? []).some((tag) => filters.tags.includes(tag))
+      : true
+    return matchesCategory && matchesSearch && matchesTags && price >= minPrice && price <= maxPrice
+  })
+
+  switch (filters.sort) {
+    case 'price-asc':
+      result = [...result].sort((a, b) => (a.price ?? 0) - (b.price ?? 0))
+      break
+    case 'price-desc':
+      result = [...result].sort((a, b) => (b.price ?? 0) - (a.price ?? 0))
+      break
+    case 'newest':
+      result = [...result].sort((a, b) => {
+        const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
+        const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
+        return bTime - aTime
+      })
+      break
+    default:
+      result = [...result].sort((a, b) => {
+        const aFeatured = a.featured || (a.tags ?? []).includes('featured')
+        const bFeatured = b.featured || (b.tags ?? []).includes('featured')
+        if (aFeatured === bFeatured) {
+          return (b.rating ?? 0) - (a.rating ?? 0)
+        }
+        return aFeatured ? -1 : 1
+      })
+  }
+
+  return result
+}
+
+export function StoreProvider({
+  children,
+  supabaseClient,
+  initialState,
+  disableInitialFetch = false,
+}: StoreProviderProps) {
+  const client = supabaseClient ?? defaultSupabase
+
+  const [catalogState, setCatalogState] = useState<CatalogState>({
+    products: initialState?.products ?? [],
+    productCache: Object.fromEntries((initialState?.products ?? []).map((product) => [product.slug, product])),
+    loading: false,
+    error: undefined,
+  })
+  const [filters, setFiltersState] = useState<CatalogFilters>(defaultFilters)
+  const [cartState, setCartState] = useState<CartState>({
+    items: initialState?.cartItems ?? [],
+    isOpen: false,
+  })
+  const [checkoutState, setCheckoutState] = useState<CheckoutState>({
+    step: 'shipping',
+    shipping: emptyShipping,
+    payment: emptyPayment,
+    status: 'idle',
+    error: undefined,
+  })
+  const [accountState, setAccountState] = useState<AccountState>({
+    profile: initialState?.profile,
+    loading: false,
+    error: undefined,
+    orders: initialState?.orders ?? [],
+  })
+
+  const [sessionUserId, setSessionUserId] = useState<string | null>(initialState?.profile?.id ?? null)
+
+  const refreshCatalog = useCallback(async () => {
+    if (!client) {
+      return
+    }
+    setCatalogState((prev) => ({ ...prev, loading: true, error: undefined }))
+    const { data, error } = await client
+      .from('products')
+      .select(
+        `id, name, slug, description, price, currency, image_url, gallery, category, tags, featured, rating, created_at, inventory_status, metadata, variants:product_variants(id, name, price, sku, stock, option_values)`
+      )
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      setCatalogState((prev) => ({ ...prev, loading: false, error: error.message }))
+      return
+    }
+
+    const products: Product[] = (data ?? []).map((item) => ({
+      id: item.id,
+      name: item.name,
+      slug: item.slug,
+      price: item.price ?? 0,
+      currency: item.currency ?? 'USD',
+      description: item.description ?? undefined,
+      image_url: item.image_url ?? undefined,
+      gallery: Array.isArray(item.gallery) ? item.gallery : item.image_url ? [item.image_url] : [],
+      category: item.category ?? undefined,
+      tags: item.tags ?? undefined,
+      featured: Boolean(item.featured),
+      rating: item.rating ?? null,
+      created_at: item.created_at ?? undefined,
+      inventory_status: item.inventory_status ?? undefined,
+      variants: item.variants ?? undefined,
+      metadata: item.metadata ?? undefined,
+    }))
+
+    setCatalogState((prev) => ({
+      ...prev,
+      loading: false,
+      products,
+      productCache: products.reduce<Record<string, Product>>((cache, product) => {
+        cache[product.id] = product
+        cache[product.slug] = product
+        return cache
+      }, {}),
+    }))
+
+    if (products.length) {
+      const prices = products.map((product) => product.price ?? 0)
+      const nextRange: [number, number] = [Math.min(...prices), Math.max(...prices)]
+      setFiltersState((prev) => ({ ...prev, priceRange: nextRange }))
+    }
+  }, [client])
+
+  const fetchProductBySlug = useCallback(
+    async (slug: string) => {
+      const cached = catalogState.productCache[slug]
+      if (cached) {
+        return cached
+      }
+
+      if (!client) {
+        return null
+      }
+
+      setCatalogState((prev) => ({ ...prev, loading: true, error: undefined }))
+
+      const { data, error } = await client
+        .from('products')
+        .select(
+          `id, name, slug, description, price, currency, image_url, gallery, category, tags, featured, rating, created_at, inventory_status, metadata, variants:product_variants(id, name, price, sku, stock, option_values)`
+        )
+        .eq('slug', slug)
+        .maybeSingle()
+
+      if (error) {
+        setCatalogState((prev) => ({ ...prev, loading: false, error: error.message }))
+        return null
+      }
+
+      if (!data) {
+        setCatalogState((prev) => ({ ...prev, loading: false }))
+        return null
+      }
+
+      const product: Product = {
+        id: data.id,
+        name: data.name,
+        slug: data.slug,
+        price: data.price ?? 0,
+        currency: data.currency ?? 'USD',
+        description: data.description ?? undefined,
+        image_url: data.image_url ?? undefined,
+        gallery: Array.isArray(data.gallery) ? data.gallery : data.image_url ? [data.image_url] : [],
+        category: data.category ?? undefined,
+        tags: data.tags ?? undefined,
+        featured: Boolean(data.featured),
+        rating: data.rating ?? null,
+        created_at: data.created_at ?? undefined,
+        inventory_status: data.inventory_status ?? undefined,
+        variants: data.variants ?? undefined,
+        metadata: data.metadata ?? undefined,
+      }
+
+      setCatalogState((prev) => ({
+        ...prev,
+        loading: false,
+        products: prev.products.some((existing) => existing.id === product.id)
+          ? prev.products.map((existing) => (existing.id === product.id ? product : existing))
+          : [...prev.products, product],
+        productCache: {
+          ...prev.productCache,
+          [product.id]: product,
+          [product.slug]: product,
+        },
+      }))
+
+      return product
+    },
+    [catalogState.productCache, client]
+  )
+
+  useEffect(() => {
+    if (!client || disableInitialFetch) {
+      return
+    }
+    refreshCatalog().catch((error) => {
+      console.error('Failed to load catalog', error)
+    })
+  }, [client, disableInitialFetch, refreshCatalog])
+
+  useEffect(() => {
+    if (!client) {
+      return
+    }
+
+    setAccountState((prev) => ({ ...prev, loading: true }))
+
+    client.auth
+      .getSession()
+      .then(({ data }) => {
+        const session = data.session
+        if (session?.user) {
+          setSessionUserId(session.user.id)
+          setAccountState((prev) => ({
+            ...prev,
+            profile: {
+              id: session.user.id,
+              email: session.user.email ?? undefined,
+              full_name: session.user.user_metadata?.full_name ?? undefined,
+              avatar_url: session.user.user_metadata?.avatar_url ?? undefined,
+            },
+            loading: false,
+            error: undefined,
+          }))
+        } else {
+          setSessionUserId(null)
+          setAccountState((prev) => ({ ...prev, profile: undefined, loading: false }))
+        }
+      })
+      .catch((error) => {
+        setAccountState((prev) => ({ ...prev, loading: false, error: error.message }))
+      })
+
+    const { data: authSubscription } = client.auth.onAuthStateChange((_, session) => {
+      if (session?.user) {
+        setSessionUserId(session.user.id)
+        setAccountState((prev) => ({
+          ...prev,
+          profile: {
+            id: session.user.id,
+            email: session.user.email ?? undefined,
+            full_name: session.user.user_metadata?.full_name ?? undefined,
+            avatar_url: session.user.user_metadata?.avatar_url ?? undefined,
+          },
+        }))
+      } else {
+        setSessionUserId(null)
+        setAccountState((prev) => ({ ...prev, profile: undefined, orders: [] }))
+      }
+    })
+
+    return () => {
+      authSubscription?.subscription.unsubscribe()
+    }
+  }, [client])
+
+  const refreshOrders = useCallback(async () => {
+    if (!client || !sessionUserId) {
+      return
+    }
+
+    setAccountState((prev) => ({ ...prev, loading: true, error: undefined }))
+
+    const { data, error } = await client
+      .from('orders')
+      .select('id, status, total, currency, created_at')
+      .eq('user_id', sessionUserId)
+      .order('created_at', { ascending: false })
+
+    if (error) {
+      setAccountState((prev) => ({ ...prev, loading: false, error: error.message }))
+      return
+    }
+
+    const orders: OrderSummary[] = (data ?? []).map((order) => ({
+      id: order.id,
+      status: order.status ?? 'processing',
+      total: order.total ?? 0,
+      currency: order.currency ?? 'USD',
+      created_at: order.created_at ?? new Date().toISOString(),
+      items: [],
+    }))
+
+    setAccountState((prev) => ({ ...prev, orders, loading: false }))
+  }, [client, sessionUserId])
+
+  useEffect(() => {
+    if (!client || !sessionUserId) {
+      return
+    }
+
+    const subscription = client
+      .channel('orders-updates')
+      .on('postgres_changes', { event: '*', schema: 'public', table: 'orders' }, (payload) => {
+        setAccountState((prev) => {
+          const existing = prev.orders.find((order) => order.id === payload.new.id)
+          if (!existing) {
+            return prev
+          }
+          return {
+            ...prev,
+            orders: prev.orders.map((order) =>
+              order.id === payload.new.id
+                ? {
+                    ...order,
+                    status: payload.new.status ?? order.status,
+                    total: payload.new.total ?? order.total,
+                  }
+                : order
+            ),
+          }
+        })
+      })
+      .subscribe()
+
+    return () => {
+      client.removeChannel(subscription)
+    }
+  }, [client, sessionUserId])
+
+  const setFilters = useCallback((nextFilters: Partial<CatalogFilters>) => {
+    setFiltersState((prev) => ({ ...prev, ...nextFilters }))
+  }, [])
+
+  const addItemToCart = useCallback((product: Product, quantity = 1, variantId?: string) => {
+    const unitPrice = variantId
+      ? product.variants?.find((variant) => variant.id === variantId)?.price ?? product.price
+      : product.price
+    const id = variantId ? `${product.id}:${variantId}` : product.id
+
+    setCartState((prev) => {
+      const existing = prev.items.find((item) => item.id === id)
+      if (existing) {
+        return {
+          ...prev,
+          items: prev.items.map((item) =>
+            item.id === id ? { ...item, quantity: item.quantity + quantity } : item
+          ),
+          isOpen: true,
+        }
+      }
+
+      const nextItem: CartItem = {
+        id,
+        productId: product.id,
+        variantId,
+        quantity,
+        unitPrice: unitPrice ?? product.price,
+        product,
+      }
+
+      return {
+        ...prev,
+        items: [...prev.items, nextItem],
+        isOpen: true,
+      }
+    })
+  }, [])
+
+  const updateItemQuantity = useCallback((id: string, quantity: number) => {
+    setCartState((prev) => ({
+      ...prev,
+      items: prev.items
+        .map((item) => (item.id === id ? { ...item, quantity } : item))
+        .filter((item) => item.quantity > 0),
+    }))
+  }, [])
+
+  const removeItemFromCart = useCallback((id: string) => {
+    setCartState((prev) => ({
+      ...prev,
+      items: prev.items.filter((item) => item.id !== id),
+    }))
+  }, [])
+
+  const clearCart = useCallback(() => {
+    setCartState((prev) => ({ ...prev, items: [] }))
+  }, [])
+
+  const openCart = useCallback(() => {
+    setCartState((prev) => ({ ...prev, isOpen: true }))
+  }, [])
+
+  const closeCart = useCallback(() => {
+    setCartState((prev) => ({ ...prev, isOpen: false }))
+  }, [])
+
+  const toggleCart = useCallback(() => {
+    setCartState((prev) => ({ ...prev, isOpen: !prev.isOpen }))
+  }, [])
+
+  const subtotal = useMemo(
+    () => cartState.items.reduce((total, item) => total + item.unitPrice * item.quantity, 0),
+    [cartState.items]
+  )
+
+  const count = useMemo(
+    () => cartState.items.reduce((total, item) => total + item.quantity, 0),
+    [cartState.items]
+  )
+
+  const goToStep = useCallback((step: CheckoutStep) => {
+    setCheckoutState((prev) => ({ ...prev, step }))
+  }, [])
+
+  const updateShipping = useCallback((details: Partial<ShippingDetails>) => {
+    setCheckoutState((prev) => ({
+      ...prev,
+      shipping: { ...prev.shipping, ...details },
+    }))
+  }, [])
+
+  const updatePayment = useCallback((details: Partial<PaymentDetails>) => {
+    setCheckoutState((prev) => ({
+      ...prev,
+      payment: { ...prev.payment, ...details },
+    }))
+  }, [])
+
+  const resetCheckout = useCallback(() => {
+    setCheckoutState({
+      step: 'shipping',
+      shipping: emptyShipping,
+      payment: emptyPayment,
+      status: 'idle',
+      error: undefined,
+    })
+  }, [])
+
+  const placeOrder = useCallback(async () => {
+    if (!client || !cartState.items.length) {
+      return
+    }
+
+    setCheckoutState((prev) => ({ ...prev, status: 'submitting', error: undefined }))
+
+    const optimisticOrder: OrderSummary = {
+      id: `temp-${Date.now()}`,
+      status: 'processing',
+      total: subtotal,
+      currency: 'USD',
+      created_at: new Date().toISOString(),
+      items: cartState.items,
+    }
+
+    setCheckoutState((prev) => ({ ...prev, lastOrder: optimisticOrder }))
+    setAccountState((prev) => ({ ...prev, orders: [optimisticOrder, ...prev.orders] }))
+
+    const payload = {
+      user_id: sessionUserId,
+      total: subtotal,
+      currency: 'USD',
+      status: 'processing',
+      items: cartState.items.map((item) => ({
+        product_id: item.productId,
+        variant_id: item.variantId ?? null,
+        quantity: item.quantity,
+        unit_price: item.unitPrice,
+      })),
+      shipping_details: checkoutState.shipping,
+      payment_method: checkoutState.payment.method,
+    }
+
+    const { data, error } = await client
+      .from('orders')
+      .insert(payload)
+      .select('id, status, total, currency, created_at')
+      .single()
+
+    if (error) {
+      setCheckoutState((prev) => ({ ...prev, status: 'error', error: error.message }))
+      setAccountState((prev) => ({
+        ...prev,
+        orders: prev.orders.filter((order) => order.id !== optimisticOrder.id),
+      }))
+      return
+    }
+
+    const persistedOrder: OrderSummary = {
+      id: data.id,
+      status: data.status ?? 'processing',
+      total: data.total ?? subtotal,
+      currency: data.currency ?? 'USD',
+      created_at: data.created_at ?? new Date().toISOString(),
+      items: cartState.items,
+    }
+
+    setCheckoutState((prev) => ({
+      ...prev,
+      status: 'success',
+      lastOrder: persistedOrder,
+      step: 'confirmation',
+    }))
+
+    setAccountState((prev) => ({
+      ...prev,
+      orders: [persistedOrder, ...prev.orders.filter((order) => order.id !== optimisticOrder.id)],
+    }))
+
+    setCartState((prev) => ({ ...prev, items: [] }))
+  }, [cartState.items, checkoutState.payment.method, checkoutState.shipping, client, sessionUserId, subtotal])
+
+  const signInWithOtp = useCallback(
+    async (email: string) => {
+      if (!client) {
+        return
+      }
+      setAccountState((prev) => ({ ...prev, loading: true, error: undefined }))
+      const { error } = await client.auth.signInWithOtp({
+        email,
+        options: {
+          emailRedirectTo: typeof window !== 'undefined' ? window.location.origin : undefined,
+        },
+      })
+      if (error) {
+        setAccountState((prev) => ({ ...prev, loading: false, error: error.message }))
+      } else {
+        setAccountState((prev) => ({ ...prev, loading: false }))
+      }
+    },
+    [client]
+  )
+
+  const signOut = useCallback(async () => {
+    if (!client) {
+      return
+    }
+    setAccountState((prev) => ({ ...prev, loading: true, error: undefined }))
+    const { error } = await client.auth.signOut()
+    if (error) {
+      setAccountState((prev) => ({ ...prev, loading: false, error: error.message }))
+      return
+    }
+    setAccountState({ profile: undefined, loading: false, error: undefined, orders: [] })
+    setSessionUserId(null)
+  }, [client])
+
+  const categories = useMemo(() => {
+    const unique = new Set<string>()
+    for (const product of catalogState.products) {
+      if (product.category) {
+        unique.add(product.category)
+      }
+    }
+    return ['all', ...Array.from(unique)]
+  }, [catalogState.products])
+
+  const filteredProducts = useMemo(
+    () => applyCatalogFilters(catalogState.products, filters),
+    [catalogState.products, filters]
+  )
+
+  const featuredProducts = useMemo(
+    () =>
+      catalogState.products.filter(
+        (product) => product.featured || (product.tags ?? []).includes('featured')
+      ),
+    [catalogState.products]
+  )
+
+  const value = useMemo<StoreContextValue>(() => ({
+    catalog: {
+      products: catalogState.products,
+      featuredProducts,
+      filteredProducts,
+      categories,
+      filters,
+      loading: catalogState.loading,
+      error: catalogState.error,
+      refresh: refreshCatalog,
+      setFilters,
+      fetchProductBySlug,
+    },
+    cart: {
+      items: cartState.items,
+      count,
+      subtotal,
+      isOpen: cartState.isOpen,
+      addItem: addItemToCart,
+      updateItemQuantity,
+      removeItem: removeItemFromCart,
+      clear: clearCart,
+      open: openCart,
+      close: closeCart,
+      toggle: toggleCart,
+    },
+    checkout: {
+      step: checkoutState.step,
+      shipping: checkoutState.shipping,
+      payment: checkoutState.payment,
+      lastOrder: checkoutState.lastOrder,
+      status: checkoutState.status,
+      error: checkoutState.error,
+      goToStep,
+      updateShipping,
+      updatePayment,
+      placeOrder,
+      reset: resetCheckout,
+    },
+    account: {
+      profile: accountState.profile,
+      loading: accountState.loading,
+      error: accountState.error,
+      orders: accountState.orders,
+      refreshOrders,
+      signInWithOtp,
+      signOut,
+    },
+  }), [
+    accountState.error,
+    accountState.loading,
+    accountState.orders,
+    accountState.profile,
+    addItemToCart,
+    cartState.isOpen,
+    cartState.items,
+    categories,
+    checkoutState.error,
+    checkoutState.lastOrder,
+    checkoutState.payment,
+    checkoutState.shipping,
+    checkoutState.status,
+    checkoutState.step,
+    clearCart,
+    closeCart,
+    count,
+    fetchProductBySlug,
+    featuredProducts,
+    filteredProducts,
+    filters,
+    goToStep,
+    openCart,
+    placeOrder,
+    refreshCatalog,
+    refreshOrders,
+    removeItemFromCart,
+    resetCheckout,
+    setFilters,
+    subtotal,
+    toggleCart,
+    updateItemQuantity,
+    updatePayment,
+    updateShipping,
+  ])
+
+  return <StoreContext.Provider value={value}>{children}</StoreContext.Provider>
+}
+
+export function useStore() {
+  const context = useContext(StoreContext)
+  if (!context) {
+    throw new Error('useStore must be used within a StoreProvider')
+  }
+  return context
+}

--- a/src/hooks/useBreakpoint.ts
+++ b/src/hooks/useBreakpoint.ts
@@ -1,0 +1,32 @@
+import { useEffect, useState } from 'react'
+
+const breakpoints: Record<'sm' | 'md' | 'lg' | 'xl' | '2xl', number> = {
+  sm: 640,
+  md: 768,
+  lg: 1024,
+  xl: 1280,
+  '2xl': 1536,
+}
+
+export function useBreakpoint(key: keyof typeof breakpoints) {
+  const [matches, setMatches] = useState(() => {
+    if (typeof window === 'undefined') {
+      return false
+    }
+    return window.matchMedia(`(min-width: ${breakpoints[key]}px)`).matches
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return undefined
+    }
+
+    const mediaQueryList = window.matchMedia(`(min-width: ${breakpoints[key]}px)`)
+    const handleChange = (event: MediaQueryListEvent) => setMatches(event.matches)
+    setMatches(mediaQueryList.matches)
+    mediaQueryList.addEventListener('change', handleChange)
+    return () => mediaQueryList.removeEventListener('change', handleChange)
+  }, [key])
+
+  return matches
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,28 +1,36 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { createBrowserRouter, RouterProvider } from 'react-router-dom'
+import AppLayout from './App'
 import './index.css'
-import App, { GettingStartedPage, HomePage } from './App'
+import AccountPage from './pages/Account'
+import CartPage from './pages/Cart'
+import CheckoutPage from './pages/Checkout'
+import HomePage from './pages/Home'
+import ProductDetailPage from './pages/ProductDetail'
+import ProductListPage from './pages/ProductList'
+import { StoreProvider } from './context/StoreContext'
+import { supabase } from './supabaseClient'
 
 const router = createBrowserRouter([
   {
     path: '/',
-    element: <App />,
+    element: <AppLayout />,
     children: [
-      {
-        index: true,
-        element: <HomePage />,
-      },
-      {
-        path: 'getting-started',
-        element: <GettingStartedPage />,
-      },
+      { index: true, element: <HomePage /> },
+      { path: 'products', element: <ProductListPage /> },
+      { path: 'products/:slug', element: <ProductDetailPage /> },
+      { path: 'cart', element: <CartPage /> },
+      { path: 'checkout', element: <CheckoutPage /> },
+      { path: 'account', element: <AccountPage /> },
     ],
   },
 ])
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <RouterProvider router={router} />
-  </React.StrictMode>,
+    <StoreProvider supabaseClient={supabase ?? undefined} disableInitialFetch={!supabase}>
+      <RouterProvider router={router} />
+    </StoreProvider>
+  </React.StrictMode>
 )

--- a/src/pages/Account.tsx
+++ b/src/pages/Account.tsx
@@ -1,0 +1,125 @@
+import { FormEvent, useEffect, useState } from 'react'
+import { useStore } from '../context/StoreContext'
+
+export default function AccountPage() {
+  const {
+    account: { profile, loading, error, orders, signInWithOtp, signOut, refreshOrders },
+  } = useStore()
+  const [email, setEmail] = useState('')
+  const [otpSent, setOtpSent] = useState(false)
+
+  useEffect(() => {
+    if (profile) {
+      refreshOrders().catch((fetchError) => {
+        console.error('Failed to refresh orders', fetchError)
+      })
+    }
+  }, [profile, refreshOrders])
+
+  const handleSignIn = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault()
+    await signInWithOtp(email)
+    setOtpSent(true)
+  }
+
+  return (
+    <div className="mx-auto flex max-w-4xl flex-col gap-8 px-4 py-12 sm:px-6">
+      <header className="space-y-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Account</p>
+        <h1 className="text-3xl font-semibold text-white">Your CozyCommerce account</h1>
+        <p className="text-sm text-slate-400">
+          Authenticate with Supabase and review your order history just like the demo.
+        </p>
+      </header>
+
+      {error && (
+        <div className="rounded-3xl border border-rose-500/70 bg-rose-500/10 p-6 text-sm text-rose-200">{error}</div>
+      )}
+
+      {!profile && (
+        <form
+          onSubmit={handleSignIn}
+          className="flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6"
+        >
+          <label className="flex flex-col gap-2 text-sm text-slate-300">
+            Email address
+            <input
+              required
+              type="email"
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              placeholder="you@example.com"
+            />
+          </label>
+          <button
+            type="submit"
+            disabled={loading}
+            className="rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300 disabled:opacity-70"
+          >
+            {loading ? 'Sending magic link…' : 'Send magic link'}
+          </button>
+          {otpSent && !loading && (
+            <p className="text-xs text-emerald-200">
+              Check your inbox for the Supabase magic link to finish signing in.
+            </p>
+          )}
+        </form>
+      )}
+
+      {profile && (
+        <div className="flex flex-col gap-6">
+          <section className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6">
+            <h2 className="text-lg font-semibold text-white">Account details</h2>
+            <p className="mt-2 text-sm text-slate-300">Signed in as {profile.email}</p>
+            {profile.full_name && <p className="text-sm text-slate-400">{profile.full_name}</p>}
+            <div className="mt-4 flex gap-3">
+              <button
+                type="button"
+                onClick={() => refreshOrders()}
+                disabled={loading}
+                className="rounded-full border border-slate-700 px-4 py-2 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white disabled:opacity-70"
+              >
+                Refresh orders
+              </button>
+              <button
+                type="button"
+                onClick={() => signOut()}
+                className="rounded-full bg-emerald-400 px-4 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+              >
+                Sign out
+              </button>
+            </div>
+          </section>
+
+          <section className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h2 className="text-lg font-semibold text-white">Order history</h2>
+                <p className="text-sm text-slate-400">Orders sync from Supabase in realtime.</p>
+              </div>
+            </div>
+            {!orders.length && !loading && (
+              <p className="mt-4 text-sm text-slate-400">No orders yet. Complete a checkout to see it here.</p>
+            )}
+            <ul className="mt-4 space-y-4">
+              {orders.map((order) => (
+                <li key={order.id} className="rounded-2xl border border-slate-800/60 bg-slate-900/70 p-4">
+                  <div className="flex flex-col gap-1 text-sm text-slate-300">
+                    <span className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+                      {order.status}
+                    </span>
+                    <span>
+                      {new Date(order.created_at).toLocaleDateString()} ·{' '}
+                      {new Intl.NumberFormat('en-US', { style: 'currency', currency: order.currency }).format(order.total)}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </section>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Cart.tsx
+++ b/src/pages/Cart.tsx
@@ -1,0 +1,107 @@
+import { Link } from 'react-router-dom'
+import { useStore } from '../context/StoreContext'
+
+export default function CartPage() {
+  const {
+    cart: { items, subtotal, updateItemQuantity, removeItem, clear },
+  } = useStore()
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12 sm:px-6">
+      <header className="flex flex-col gap-2">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Cart</p>
+        <h1 className="text-3xl font-semibold text-white">Your bag</h1>
+        <p className="text-sm text-slate-400">Review items before heading to checkout.</p>
+      </header>
+
+      {!items.length && (
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 text-sm text-slate-400">
+          Your cart is empty. Browse the <Link to="/products" className="text-emerald-300 hover:text-emerald-200">shop</Link> to add products.
+        </div>
+      )}
+
+      {items.length > 0 && (
+        <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+          <ul className="space-y-6">
+            {items.map((item) => (
+              <li key={item.id} className="flex gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-4">
+                <div className="h-32 w-32 overflow-hidden rounded-2xl border border-slate-800/60 bg-slate-900/70">
+                  {item.product.gallery?.[0] ? (
+                    <img src={item.product.gallery[0]} alt={item.product.name} className="h-full w-full object-cover" />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-xs text-slate-500">No image</div>
+                  )}
+                </div>
+                <div className="flex flex-1 flex-col gap-3">
+                  <div className="flex items-start justify-between">
+                    <div>
+                      <h3 className="text-lg font-semibold text-white">{item.product.name}</h3>
+                      <p className="text-xs uppercase tracking-[0.3em] text-slate-400">
+                        {item.product.category ?? 'General'}
+                      </p>
+                    </div>
+                    <button
+                      type="button"
+                      onClick={() => removeItem(item.id)}
+                      className="text-xs font-semibold text-slate-400 transition hover:text-emerald-300"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                  <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => updateItemQuantity(item.id, Math.max(1, item.quantity - 1))}
+                        className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-800/60 text-sm text-slate-300 transition hover:border-slate-700 hover:text-white"
+                        aria-label="Decrease quantity"
+                      >
+                        −
+                      </button>
+                      <span className="w-10 text-center text-sm text-white">{item.quantity}</span>
+                      <button
+                        type="button"
+                        onClick={() => updateItemQuantity(item.id, item.quantity + 1)}
+                        className="flex h-8 w-8 items-center justify-center rounded-full border border-slate-800/60 text-sm text-slate-300 transition hover:border-slate-700 hover:text-white"
+                        aria-label="Increase quantity"
+                      >
+                        +
+                      </button>
+                    </div>
+                    <span className="text-sm font-semibold text-emerald-300">
+                      {new Intl.NumberFormat('en-US', {
+                        style: 'currency',
+                        currency: item.product.currency ?? 'USD',
+                      }).format(item.unitPrice * item.quantity)}
+                    </span>
+                  </div>
+                </div>
+              </li>
+            ))}
+          </ul>
+          <aside className="flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6">
+            <h2 className="text-lg font-semibold text-white">Summary</h2>
+            <div className="flex justify-between text-sm text-slate-300">
+              <span>Subtotal</span>
+              <span>{new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(subtotal)}</span>
+            </div>
+            <p className="text-xs text-slate-500">Taxes and shipping are calculated during checkout.</p>
+            <Link
+              to="/checkout"
+              className="rounded-full bg-emerald-400 px-6 py-3 text-center text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            >
+              Checkout
+            </Link>
+            <button
+              type="button"
+              onClick={clear}
+              className="rounded-full border border-slate-700 px-6 py-3 text-sm font-semibold text-slate-100 transition hover:border-slate-500 hover:text-white"
+            >
+              Clear cart
+            </button>
+          </aside>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/pages/Checkout.tsx
+++ b/src/pages/Checkout.tsx
@@ -1,0 +1,30 @@
+import CheckoutForms from '../components/checkout/CheckoutForms'
+import CheckoutStepper from '../components/checkout/CheckoutStepper'
+import { useStore } from '../context/StoreContext'
+
+export default function CheckoutPage() {
+  const {
+    checkout: { step, goToStep },
+    cart: { items },
+  } = useStore()
+
+  return (
+    <div className="mx-auto flex max-w-5xl flex-col gap-8 px-4 py-12 sm:px-6">
+      <header className="space-y-3">
+        <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Checkout</p>
+        <h1 className="text-3xl font-semibold text-white">Complete your order</h1>
+        <p className="text-sm text-slate-400">Follow the guided steps to mirror CozyCommerce’s checkout flow.</p>
+      </header>
+
+      <CheckoutStepper currentStep={step} onStepChange={goToStep} />
+
+      {!items.length && (
+        <div className="rounded-3xl border border-amber-500/60 bg-amber-500/10 p-6 text-sm text-amber-200">
+          Your cart is empty. Add items from the shop before checking out.
+        </div>
+      )}
+
+      <CheckoutForms />
+    </div>
+  )
+}

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -1,0 +1,87 @@
+import HeroBanner from '../components/HeroBanner'
+import ProductCarousel from '../components/ProductCarousel'
+import ProductCard from '../components/ProductCard'
+import { useStore } from '../context/StoreContext'
+
+export default function HomePage() {
+  const {
+    catalog: { products, featuredProducts, filteredProducts, loading, error },
+  } = useStore()
+
+  const newArrivals = products
+    .filter((product) => (product.tags ?? []).includes('new'))
+    .slice(0, 6)
+  const editorPicks = filteredProducts.slice(0, 6)
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-12 sm:px-6">
+      <HeroBanner
+        eyebrow="New collection"
+        title="Thoughtfully curated home goods"
+        description="Bring the CozyCommerce experience into your projects with Supabase-powered catalog data and frictionless checkout flows."
+        primaryCta={{ label: 'Shop the collection', to: '/products' }}
+        secondaryCta={{ label: 'View cart', to: '/cart' }}
+        backgroundImage="https://images.unsplash.com/photo-1505691938895-1758d7feb511?auto=format&fit=crop&w=1400&q=80"
+        align="left"
+      />
+
+      {loading && (
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+          {Array.from({ length: 3 }).map((_, index) => (
+            <div
+              key={index}
+              className="animate-pulse rounded-3xl border border-slate-800/60 bg-slate-900/60 p-6"
+            >
+              <div className="mb-4 h-40 rounded-2xl bg-slate-800/70" />
+              <div className="mb-2 h-4 w-3/4 rounded-full bg-slate-800/70" />
+              <div className="h-4 w-1/2 rounded-full bg-slate-800/60" />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="rounded-3xl border border-rose-500/70 bg-rose-500/10 p-6 text-sm text-rose-200">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && featuredProducts.length > 0 && (
+        <ProductCarousel
+          title="Featured pieces"
+          subtitle="Handpicked hero products from the CozyCommerce demo"
+          products={featuredProducts}
+        />
+      )}
+
+      {!loading && !error && newArrivals.length > 0 && (
+        <ProductCarousel
+          title="New arrivals"
+          subtitle="Fresh designs that just landed in store"
+          products={newArrivals}
+        />
+      )}
+
+      <section className="grid gap-6 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 sm:grid-cols-2">
+        {editorPicks.slice(0, 4).map((product) => (
+          <ProductCard key={product.id} product={product} showDescription />
+        ))}
+      </section>
+
+      <section className="grid gap-6 sm:grid-cols-3">
+        {["Warm lighting", 'Soft textiles', 'Plant-forward living'].map((title, index) => (
+          <div
+            key={title}
+            className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 shadow-lg shadow-slate-950/30"
+          >
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Inspiration {index + 1}</p>
+            <h3 className="mt-3 text-xl font-semibold text-white">{title}</h3>
+            <p className="mt-2 text-sm text-slate-400">
+              Recreate the CozyCommerce aesthetic with curated lighting, textiles, and botanicals designed to glow across any screen size.
+            </p>
+          </div>
+        ))}
+      </section>
+    </div>
+  )
+}

--- a/src/pages/ProductDetail.tsx
+++ b/src/pages/ProductDetail.tsx
@@ -1,0 +1,205 @@
+import { useEffect, useMemo, useState } from 'react'
+import { useParams } from 'react-router-dom'
+import ProductCarousel from '../components/ProductCarousel'
+import { Product, useStore } from '../context/StoreContext'
+
+export default function ProductDetailPage() {
+  const { slug } = useParams<{ slug: string }>()
+  const {
+    catalog: { products, fetchProductBySlug, loading, error },
+    cart: { addItem },
+  } = useStore()
+
+  const matchingProduct = useMemo(
+    () => products.find((product) => product.slug === slug),
+    [products, slug]
+  )
+
+  const [product, setProduct] = useState<Product | null>(matchingProduct ?? null)
+  const [quantity, setQuantity] = useState(1)
+  const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>(
+    matchingProduct?.variants?.[0]?.id ?? undefined
+  )
+  const [selectedImageIndex, setSelectedImageIndex] = useState(0)
+  const [status, setStatus] = useState<'idle' | 'loading' | 'error' | 'success'>(
+    matchingProduct ? 'success' : loading ? 'loading' : 'idle'
+  )
+
+  useEffect(() => {
+    setProduct(matchingProduct ?? null)
+    setSelectedVariantId(matchingProduct?.variants?.[0]?.id ?? undefined)
+    setStatus(matchingProduct ? 'success' : 'idle')
+    setSelectedImageIndex(0)
+  }, [matchingProduct])
+
+  useEffect(() => {
+    if (!slug || product) {
+      return
+    }
+
+    setStatus('loading')
+    fetchProductBySlug(slug)
+      .then((fetched) => {
+        if (fetched) {
+          setProduct(fetched)
+          setSelectedVariantId(fetched.variants?.[0]?.id ?? undefined)
+          setStatus('success')
+        } else {
+          setStatus('error')
+        }
+      })
+      .catch(() => setStatus('error'))
+  }, [fetchProductBySlug, product, slug])
+
+  if (!slug) {
+    return <div className="mx-auto max-w-6xl px-4 py-10 text-slate-400">Product unavailable.</div>
+  }
+
+  if (status === 'loading') {
+    return <div className="mx-auto max-w-6xl px-4 py-10 text-slate-400">Loading product details…</div>
+  }
+
+  if ((status === 'error' || error) && !product) {
+    return (
+      <div className="mx-auto max-w-6xl px-4 py-10 text-slate-400">
+        We couldn’t find this product in Supabase. It may have been removed.
+      </div>
+    )
+  }
+
+  if (!product) {
+    return null
+  }
+
+  const priceLabel = new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: product.currency ?? 'USD',
+  }).format(product.price ?? 0)
+
+  const variant = product.variants?.find((item) => item.id === selectedVariantId)
+
+  const recommended = products.filter(
+    (candidate) => candidate.id !== product.id && candidate.category === product.category
+  )
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-12 px-4 py-12 sm:px-6">
+      <div className="grid gap-8 lg:grid-cols-2">
+        <div className="space-y-4">
+          <div className="overflow-hidden rounded-3xl border border-slate-800/60 bg-slate-900/70">
+            {product.gallery?.[selectedImageIndex] ? (
+              <img
+                src={product.gallery[selectedImageIndex]}
+                alt={product.name}
+                className="h-full w-full object-cover"
+              />
+            ) : (
+              <div className="flex h-72 items-center justify-center text-sm text-slate-400">Image coming soon</div>
+            )}
+          </div>
+          {product.gallery && product.gallery.length > 1 && (
+            <div className="flex gap-3 overflow-x-auto pb-2">
+              {product.gallery.map((image, index) => (
+                <button
+                  type="button"
+                  key={image}
+                  onClick={() => {
+                    setSelectedImageIndex(index)
+                    if (product.variants && product.variants[index]) {
+                      setSelectedVariantId(product.variants[index]?.id)
+                    }
+                  }}
+                  className={`relative h-24 w-24 overflow-hidden rounded-2xl border transition ${
+                    index === selectedImageIndex
+                      ? 'border-emerald-400/80'
+                      : 'border-slate-800/60 hover:border-slate-700'
+                  }`}
+                >
+                  <img src={image} alt="Product preview" className="h-full w-full object-cover" />
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="flex flex-col gap-6 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6">
+          <div>
+            <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">
+              {product.category ?? 'Collection'}
+            </p>
+            <h1 className="mt-2 text-3xl font-semibold text-white">{product.name}</h1>
+            <p className="mt-3 text-base text-slate-300">{product.description}</p>
+          </div>
+          <div className="flex items-baseline gap-3 text-3xl font-semibold text-emerald-300">
+            {priceLabel}
+            {variant?.price && variant.price !== product.price && (
+              <span className="text-base font-medium text-slate-400">
+                Variant price: {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(variant.price)}
+              </span>
+            )}
+          </div>
+          {product.variants && product.variants.length > 0 && (
+            <div className="grid gap-3">
+              <p className="text-xs font-semibold uppercase tracking-[0.3em] text-slate-400">Options</p>
+              <div className="flex flex-wrap gap-3">
+                {product.variants.map((item) => (
+                  <button
+                    key={item.id}
+                    type="button"
+                    onClick={() => setSelectedVariantId(item.id)}
+                    className={`rounded-full px-4 py-2 text-sm transition ${
+                      item.id === selectedVariantId
+                        ? 'bg-emerald-400 text-slate-950 shadow shadow-emerald-500/20'
+                        : 'border border-slate-800/60 bg-slate-900/80 text-slate-300 hover:border-slate-700'
+                    }`}
+                  >
+                    {item.name}
+                  </button>
+                ))}
+              </div>
+            </div>
+          )}
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-2 rounded-full border border-slate-800/60 px-3 py-1">
+              <button
+                type="button"
+                onClick={() => setQuantity((prev) => Math.max(1, prev - 1))}
+                className="h-8 w-8 rounded-full text-lg text-slate-300 transition hover:bg-slate-900/80 hover:text-white"
+                aria-label="Decrease quantity"
+              >
+                −
+              </button>
+              <span className="w-10 text-center text-sm text-white">{quantity}</span>
+              <button
+                type="button"
+                onClick={() => setQuantity((prev) => prev + 1)}
+                className="h-8 w-8 rounded-full text-lg text-slate-300 transition hover:bg-slate-900/80 hover:text-white"
+                aria-label="Increase quantity"
+              >
+                +
+              </button>
+            </div>
+            <button
+              type="button"
+              onClick={() => addItem(product, quantity, selectedVariantId)}
+              className="flex-1 rounded-full bg-emerald-400 px-6 py-2 text-sm font-semibold text-slate-950 transition hover:bg-emerald-300"
+            >
+              Add to cart
+            </button>
+          </div>
+          {product.inventory_status && (
+            <p className="text-xs uppercase tracking-[0.3em] text-slate-400">{product.inventory_status}</p>
+          )}
+        </div>
+      </div>
+
+      {recommended.length > 0 && (
+        <ProductCarousel
+          title="You may also like"
+          subtitle="Complementary products from the same collection"
+          products={recommended.slice(0, 6)}
+        />
+      )}
+    </div>
+  )
+}

--- a/src/pages/ProductList.tsx
+++ b/src/pages/ProductList.tsx
@@ -1,0 +1,92 @@
+import { ChangeEvent } from 'react'
+import ProductCard from '../components/ProductCard'
+import { useStore } from '../context/StoreContext'
+
+export default function ProductListPage() {
+  const {
+    catalog: { filteredProducts, categories, filters, loading, error, setFilters },
+  } = useStore()
+
+  const handleSearchChange = (event: ChangeEvent<HTMLInputElement>) => {
+    setFilters({ searchTerm: event.target.value })
+  }
+
+  const handleCategoryChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setFilters({ category: event.target.value as typeof filters.category })
+  }
+
+  const handleSortChange = (event: ChangeEvent<HTMLSelectElement>) => {
+    setFilters({ sort: event.target.value as typeof filters.sort })
+  }
+
+  return (
+    <div className="mx-auto flex max-w-6xl flex-col gap-8 px-4 py-10 sm:px-6">
+      <header className="flex flex-col gap-4 rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 sm:flex-row sm:items-end sm:justify-between">
+        <div className="space-y-2">
+          <p className="text-xs font-semibold uppercase tracking-[0.3em] text-emerald-300">Shop the collection</p>
+          <h1 className="text-3xl font-semibold text-white">All products</h1>
+          <p className="text-sm text-slate-400">
+            Filter by category, search, or sort to explore the CozyCommerce catalog fetched from Supabase.
+          </p>
+        </div>
+        <div className="grid gap-3 sm:grid-cols-3">
+          <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Search
+            <input
+              type="search"
+              value={filters.searchTerm}
+              onChange={handleSearchChange}
+              className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+              placeholder="Search products"
+            />
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Category
+            <select
+              value={filters.category}
+              onChange={handleCategoryChange}
+              className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+            >
+              {categories.map((category) => (
+                <option key={category} value={category}>
+                  {category === 'all' ? 'All products' : category}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="flex flex-col gap-2 text-xs font-semibold uppercase tracking-widest text-slate-400">
+            Sort
+            <select
+              value={filters.sort}
+              onChange={handleSortChange}
+              className="rounded-xl border border-slate-800/60 bg-slate-900/80 px-3 py-2 text-sm text-white focus:border-emerald-400 focus:outline-none"
+            >
+              <option value="featured">Featured</option>
+              <option value="price-asc">Price: Low to High</option>
+              <option value="price-desc">Price: High to Low</option>
+              <option value="newest">Newest first</option>
+            </select>
+          </label>
+        </div>
+      </header>
+
+      {loading && <p className="text-sm text-slate-400">Loading catalog from Supabase…</p>}
+
+      {error && (
+        <div className="rounded-3xl border border-rose-500/70 bg-rose-500/10 p-6 text-sm text-rose-200">{error}</div>
+      )}
+
+      <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
+        {filteredProducts.map((product) => (
+          <ProductCard key={product.id} product={product} />
+        ))}
+      </section>
+
+      {!loading && !filteredProducts.length && (
+        <div className="rounded-3xl border border-slate-800/60 bg-slate-950/70 p-6 text-sm text-slate-400">
+          No products match your filters. Try adjusting your search or category selection.
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/supabaseClient.ts
+++ b/src/supabaseClient.ts
@@ -1,14 +1,17 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, type SupabaseClient } from '@supabase/supabase-js'
 
 const supabaseUrl = import.meta.env.VITE_SUPABASE_URL
 const supabaseAnonKey = import.meta.env.VITE_SUPABASE_ANON_KEY
 
-if (!supabaseUrl) {
-  throw new Error('Missing VITE_SUPABASE_URL environment variable.')
+let client: SupabaseClient | null = null
+
+if (typeof supabaseUrl === 'string' && typeof supabaseAnonKey === 'string' && supabaseUrl && supabaseAnonKey) {
+  client = createClient(supabaseUrl, supabaseAnonKey)
+} else if (typeof window === 'undefined') {
+  // Tests and build environments might not provide Supabase credentials.
+  // eslint-disable-next-line no-console
+  console.warn('Supabase client is not configured. Provide VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY to enable data fetching.')
 }
 
-if (!supabaseAnonKey) {
-  throw new Error('Missing VITE_SUPABASE_ANON_KEY environment variable.')
-}
-
-export const supabase = createClient(supabaseUrl, supabaseAnonKey)
+export const supabase = client
+export type { SupabaseClient }

--- a/src/tests/setup.ts
+++ b/src/tests/setup.ts
@@ -1,0 +1,55 @@
+import '@testing-library/jest-dom'
+import { vi } from 'vitest'
+
+type MatchMediaQuery = {
+  matches: boolean
+  media: string
+  onchange: ((this: MediaQueryList, ev: MediaQueryListEvent) => void) | null
+  addEventListener: (type: 'change', listener: (event: MediaQueryListEvent) => void) => void
+  removeEventListener: (type: 'change', listener: (event: MediaQueryListEvent) => void) => void
+  addListener: (listener: (event: MediaQueryListEvent) => void) => void
+  removeListener: (listener: (event: MediaQueryListEvent) => void) => void
+  dispatchEvent: (event: Event) => boolean
+}
+
+function createMatchMedia(width: number) {
+  return (query: string): MatchMediaQuery => {
+    const minWidthMatch = /\(min-width:\s*(\d+)px\)/.exec(query)
+    const minWidth = minWidthMatch ? Number.parseInt(minWidthMatch[1] ?? '0', 10) : 0
+    const matches = width >= minWidth
+    const listeners = new Set<(event: MediaQueryListEvent) => void>()
+    return {
+      matches,
+      media: query,
+      onchange: null,
+      addEventListener: (_type, listener) => {
+        listeners.add(listener)
+      },
+      removeEventListener: (_type, listener) => {
+        listeners.delete(listener)
+      },
+      addListener: (listener) => listeners.add(listener),
+      removeListener: (listener) => listeners.delete(listener),
+      dispatchEvent: (event) => {
+        listeners.forEach((listener) => listener(event as MediaQueryListEvent))
+        return true
+      },
+    }
+  }
+}
+
+declare global {
+  // eslint-disable-next-line no-var
+  var setScreenWidth: (width: number) => void
+}
+
+const initialWidth = 1024
+
+Object.defineProperty(window, 'matchMedia', {
+  writable: true,
+  value: vi.fn(createMatchMedia(initialWidth)),
+})
+
+globalThis.setScreenWidth = (width: number) => {
+  window.matchMedia = vi.fn(createMatchMedia(width))
+}

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -11,7 +11,7 @@
     "moduleResolution": "Bundler",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "types": ["vite/client"],
+    "types": ["vite/client", "vitest/globals"],
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -10,4 +10,9 @@ export default defineConfig({
       '@': fileURLToPath(new URL('./src', import.meta.url)),
     },
   },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    setupFiles: './src/tests/setup.ts',
+  },
 })


### PR DESCRIPTION
## Summary
- build a Supabase-aware store context that manages catalog filters, cart contents, checkout flow, and account data while wiring up optimistic order mutations
- replace the landing page shell with a routed CozyCommerce experience covering home, product listing/detail, cart, checkout, and account views plus reusable UI primitives
- introduce responsive navigation, product presentation, cart drawer, and checkout components along with vitest-powered breakpoint checks and test setup utilities

## Testing
- `npm run lint` *(fails: missing @eslint/js because npm registry returned 403)*
- `npm run test` *(fails: vitest not installed because npm registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68cee2037de08330ae68a6aafb584823