### PR TITLE
Add Supabase schema and admin console

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,3 +55,55 @@ By default the app runs at [http://localhost:5173](http://localhost:5173). The C
 ```
 
 Use the `supabase` instance exported from `src/supabaseClient.ts` inside your React components or data loaders to interact with your backend.
+
+## Database schema & migrations
+
+The `supabase/migrations/0001_ecommerce_schema.sql` migration provisions the full commerce schema, including:
+
+- Catalog entities (`categories`, `products`, `media`, `settings`).
+- Customer lifecycle tables (`customers`, `orders`, `order_items`).
+- Operational helpers (`inventory_events`, `admin_audit_logs`).
+- Role-based access control (`app_user_roles` with helper functions `is_admin()` / `is_customer()`).
+
+Row-level security (RLS) is enabled everywhere. Policies ensure shoppers can read public data and access only their own records while administrators (members of `app_user_roles` with role `admin`) receive full CRUD rights. Three RPC helpers are included for complex workflows:
+
+- `admin_adjust_inventory` – adjusts stock levels, persists an inventory event, and writes to the audit log.
+- `admin_update_order_status` – transitions an order to a new status, stamping fulfillment/cancellation timestamps and logging the action.
+- `admin_register_media_asset` – stores metadata for files uploaded through the admin console and logs the change.
+
+The `supabase/functions/admin-upload-media` edge function issues signed upload URLs for Supabase Storage, verifies that the caller is an admin, and invokes `admin_register_media_asset` for bookkeeping.
+
+## Authentication & roles
+
+Email-based sign-in (password or OTP) is supported out of the box by enabling the **Email** provider in the Supabase dashboard (`Authentication → Providers`). A trigger created in the migration keeps the `customers` table synchronized with new `auth.users` entries and ensures every sign-up gets at least the `customer` role in `app_user_roles`.
+
+To promote a user to an administrator run the following SQL (replace the `user_id` with a valid UUID from `auth.users`):
+
+```sql
+insert into app_user_roles (user_id, role)
+values ('00000000-0000-0000-0000-000000000000', 'admin')
+on conflict (user_id) do update set role = excluded.role;
+```
+
+## Admin console
+
+Navigate to `/admin` after signing in. Routes are protected by Supabase session checks and the `app_user_roles` table:
+
+- **Catalog** – manage products/categories, perform inventory adjustments via the `admin_adjust_inventory` RPC, and toggle product statuses.
+- **Orders** – monitor recent orders, update fulfillment states (calls `admin_update_order_status`), and leave audit-trailed notes.
+- **Analytics** – visualize 30-day revenue, review recent inventory adjustments, and inspect audit log entries.
+- **Content** – edit JSON storefront settings, request media upload URLs through the `admin-upload-media` edge function, and review recent assets.
+
+Every critical action (inventory adjustments, status changes, settings updates, media uploads) asks for confirmation before calling the backend and results in an `admin_audit_logs` entry.
+
+## Seeding demo data
+
+Load `supabase/seeds/demo_seed.sql` to quickly populate the catalog:
+
+```bash
+supabase db remote commit supabase/seeds/demo_seed.sql
+# or, when using the local CLI:
+supabase db execute --file supabase/seeds/demo_seed.sql
+```
+
+The seed file creates sample categories, products, settings, and inventory snapshots so the storefront and admin dashboards have realistic data.

--- a/src/hooks/useAdminSession.ts
+++ b/src/hooks/useAdminSession.ts
@@ -1,0 +1,116 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import type { Session } from '@supabase/supabase-js'
+import { supabase } from '../supabaseClient'
+
+export interface AdminSessionState {
+  session: Session | null
+  isAdmin: boolean
+  role: 'admin' | 'customer' | null
+  loading: boolean
+  error?: string
+  refresh: () => Promise<void>
+}
+
+const roleTable = 'app_user_roles'
+
+export function useAdminSession(): AdminSessionState {
+  const client = supabase
+  const [session, setSession] = useState<Session | null>(null)
+  const [role, setRole] = useState<'admin' | 'customer' | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | undefined>()
+
+  const fetchRole = useCallback(
+    async (userId: string | undefined | null) => {
+      if (!client) {
+        setRole(null)
+        setError('Supabase client is not configured')
+        setLoading(false)
+        return
+      }
+
+      if (!userId) {
+        setRole(null)
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+
+      const { data, error: roleError } = await client
+        .from(roleTable)
+        .select('role')
+        .eq('user_id', userId)
+        .maybeSingle()
+
+      if (roleError) {
+        setError(roleError.message)
+        setRole(null)
+      } else if (data?.role === 'admin') {
+        setRole('admin')
+      } else if (data?.role) {
+        setRole('customer')
+      } else {
+        setRole(null)
+      }
+
+      setLoading(false)
+    },
+    [client],
+  )
+
+  useEffect(() => {
+    if (!client) {
+      setLoading(false)
+      setError('Supabase client is not configured')
+      return
+    }
+
+    let isMounted = true
+
+    client.auth
+      .getSession()
+      .then(({ data, error: sessionError }) => {
+        if (!isMounted) return
+
+        if (sessionError) {
+          setError(sessionError.message)
+          setSession(null)
+          setRole(null)
+          setLoading(false)
+          return
+        }
+
+        const currentSession = data?.session ?? null
+        setSession(currentSession)
+        void fetchRole(currentSession?.user?.id)
+      })
+
+    const { data: listener } = client.auth.onAuthStateChange((_event, nextSession) => {
+      if (!isMounted) return
+      setSession(nextSession)
+      void fetchRole(nextSession?.user?.id)
+    })
+
+    return () => {
+      isMounted = false
+      listener?.subscription.unsubscribe()
+    }
+  }, [client, fetchRole])
+
+  const refresh = useCallback(async () => {
+    await fetchRole(session?.user?.id)
+  }, [fetchRole, session?.user?.id])
+
+  return useMemo(
+    () => ({
+      session,
+      isAdmin: role === 'admin',
+      role,
+      loading,
+      error,
+      refresh,
+    }),
+    [session, role, loading, error, refresh],
+  )
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -9,6 +9,12 @@ import CheckoutPage from './pages/Checkout'
 import HomePage from './pages/Home'
 import ProductDetailPage from './pages/ProductDetail'
 import ProductListPage from './pages/ProductList'
+import AdminLayout from './pages/admin/AdminLayout'
+import AnalyticsPage from './pages/admin/AnalyticsPage'
+import CatalogManagementPage from './pages/admin/CatalogManagementPage'
+import ContentManagementPage from './pages/admin/ContentManagementPage'
+import OrderFulfillmentPage from './pages/admin/OrderFulfillmentPage'
+import ProtectedAdminRoute from './pages/admin/ProtectedAdminRoute'
 import { StoreProvider } from './context/StoreContext'
 import { supabase } from './supabaseClient'
 
@@ -23,6 +29,21 @@ const router = createBrowserRouter([
       { path: 'cart', element: <CartPage /> },
       { path: 'checkout', element: <CheckoutPage /> },
       { path: 'account', element: <AccountPage /> },
+    ],
+  },
+  {
+    path: '/admin',
+    element: (
+      <ProtectedAdminRoute>
+        <AdminLayout />
+      </ProtectedAdminRoute>
+    ),
+    children: [
+      { index: true, element: <CatalogManagementPage /> },
+      { path: 'catalog', element: <CatalogManagementPage /> },
+      { path: 'orders', element: <OrderFulfillmentPage /> },
+      { path: 'analytics', element: <AnalyticsPage /> },
+      { path: 'content', element: <ContentManagementPage /> },
     ],
   },
 ])

--- a/src/pages/admin/AdminLayout.tsx
+++ b/src/pages/admin/AdminLayout.tsx
@@ -1,0 +1,89 @@
+import { NavLink, Outlet } from 'react-router-dom'
+import { useAdminSession } from '../../hooks/useAdminSession'
+import { supabase } from '../../supabaseClient'
+
+const navItems = [
+  {
+    to: '/admin/catalog',
+    title: 'Catalog',
+    description: 'Products, categories, inventory adjustments',
+  },
+  {
+    to: '/admin/orders',
+    title: 'Orders',
+    description: 'Monitor order queues and fulfillment tasks',
+  },
+  {
+    to: '/admin/analytics',
+    title: 'Analytics',
+    description: 'Sales performance, conversion rates, and trends',
+  },
+  {
+    to: '/admin/content',
+    title: 'Content',
+    description: 'Homepage, merchandising blocks, and media assets',
+  },
+]
+
+export default function AdminLayout() {
+  const { session } = useAdminSession()
+
+  const handleSignOut = async () => {
+    if (!supabase) return
+    const confirmed = window.confirm('Sign out of the admin console?')
+    if (!confirmed) return
+    await supabase.auth.signOut()
+  }
+
+  return (
+    <div className="flex min-h-screen bg-slate-950 text-slate-100">
+      <aside className="hidden w-72 flex-shrink-0 border-r border-slate-800/60 bg-slate-950/70 px-6 py-8 lg:block">
+        <div className="mb-10">
+          <p className="text-xs uppercase tracking-wider text-slate-500">Evolvencia Admin</p>
+          <p className="mt-2 text-lg font-semibold text-emerald-300">Operations Console</p>
+        </div>
+        <nav className="space-y-4">
+          {navItems.map((item) => (
+            <NavLink
+              key={item.to}
+              to={item.to}
+              className={({ isActive }) =>
+                `block rounded-lg border px-4 py-3 text-sm transition ${
+                  isActive
+                    ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-200 shadow'
+                    : 'border-slate-800/60 bg-slate-950/40 text-slate-300 hover:border-emerald-500/40 hover:text-emerald-200'
+                }`
+              }
+            >
+              <p className="font-semibold">{item.title}</p>
+              <p className="mt-1 text-xs text-slate-400">{item.description}</p>
+            </NavLink>
+          ))}
+        </nav>
+      </aside>
+      <main className="flex-1">
+        <header className="flex flex-col gap-3 border-b border-slate-800/70 bg-slate-950/80 px-6 py-4 text-sm text-slate-300 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="text-xs uppercase tracking-widest text-slate-500">Signed in as</p>
+            <p className="text-base font-semibold text-slate-100">{session?.user.email ?? 'Unknown user'}</p>
+          </div>
+          <div className="flex items-center gap-3">
+            <span className="rounded-full border border-emerald-500/40 bg-emerald-500/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-emerald-300">
+              Admin
+            </span>
+            <button
+              type="button"
+              onClick={handleSignOut}
+              className="rounded-md border border-slate-700/70 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-slate-300 transition hover:border-rose-500/50 hover:text-rose-200"
+            >
+              Sign out
+            </button>
+          </div>
+        </header>
+        <section className="min-h-[calc(100vh-80px)] bg-gradient-to-b from-slate-950 via-slate-900 to-slate-950 px-4 py-6 md:px-8 md:py-10">
+          <Outlet />
+        </section>
+      </main>
+    </div>
+  )
+}

--- a/src/pages/admin/AnalyticsPage.tsx
+++ b/src/pages/admin/AnalyticsPage.tsx
@@ -1,0 +1,200 @@
+import { useEffect, useMemo, useState } from 'react'
+import { supabase } from '../../supabaseClient'
+
+type RevenueBreakdown = Record<string, number>
+
+type DailySales = Array<{ date: string; total: number }>
+
+type InventoryEvent = {
+  id: string
+  product_id: string
+  quantity_delta: number
+  reason: string | null
+  resulting_quantity: number
+  created_at: string
+}
+
+type AuditLog = {
+  id: number
+  action: string
+  target_table: string | null
+  target_id: string | null
+  created_at: string
+  metadata: Record<string, unknown>
+}
+
+export default function AnalyticsPage() {
+  const client = supabase
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [revenue, setRevenue] = useState<RevenueBreakdown>({})
+  const [dailySales, setDailySales] = useState<DailySales>([])
+  const [inventoryEvents, setInventoryEvents] = useState<InventoryEvent[]>([])
+  const [auditLog, setAuditLog] = useState<AuditLog[]>([])
+
+  useEffect(() => {
+    const fetchAnalytics = async () => {
+      if (!client) {
+        setError('Supabase client is not configured')
+        setLoading(false)
+        return
+      }
+
+      setLoading(true)
+      setError(null)
+      const thirtyDaysAgo = new Date()
+      thirtyDaysAgo.setDate(thirtyDaysAgo.getDate() - 30)
+
+      const [{ data: orderData, error: ordersError }, { data: eventData, error: eventError }, { data: auditData, error: auditError }]
+        = await Promise.all([
+          client
+            .from('orders')
+            .select('status, total_cents, placed_at')
+            .gte('placed_at', thirtyDaysAgo.toISOString()),
+          client
+            .from('inventory_events')
+            .select('id, product_id, quantity_delta, reason, resulting_quantity, created_at')
+            .order('created_at', { ascending: false })
+            .limit(5),
+          client
+            .from('admin_audit_logs')
+            .select('id, action, target_table, target_id, created_at, metadata')
+            .order('created_at', { ascending: false })
+            .limit(5),
+        ])
+
+      if (ordersError || eventError || auditError) {
+        setError(ordersError?.message ?? eventError?.message ?? auditError?.message ?? 'Unable to load analytics')
+        setLoading(false)
+        return
+      }
+
+      const revenueTotals: RevenueBreakdown = {}
+      const dailyTotals = new Map<string, number>()
+
+      for (const order of orderData ?? []) {
+        const statusKey = order.status ?? 'unknown'
+        const dateKey = new Date(order.placed_at).toISOString().slice(0, 10)
+        revenueTotals[statusKey] = (revenueTotals[statusKey] ?? 0) + order.total_cents
+        dailyTotals.set(dateKey, (dailyTotals.get(dateKey) ?? 0) + order.total_cents)
+      }
+
+      const formattedDailySales: DailySales = Array.from(dailyTotals.entries())
+        .sort(([a], [b]) => (a > b ? 1 : -1))
+        .map(([date, total]) => ({ date, total }))
+
+      setRevenue(revenueTotals)
+      setDailySales(formattedDailySales)
+      setInventoryEvents((eventData ?? []) as InventoryEvent[])
+      setAuditLog((auditData ?? []) as AuditLog[])
+      setLoading(false)
+    }
+
+    void fetchAnalytics()
+  }, [client])
+
+  const revenueTotal = useMemo(() => Object.values(revenue).reduce((sum, amount) => sum + amount, 0), [revenue])
+  const formattedDailySales = useMemo(
+    () =>
+      dailySales.map((entry) => ({
+        date: new Date(entry.date).toLocaleDateString(undefined, { month: 'short', day: 'numeric' }),
+        total: entry.total / 100,
+      })),
+    [dailySales],
+  )
+
+  if (loading) {
+    return <div className="text-sm text-slate-300">Loading analytics…</div>
+  }
+
+  if (!client) {
+    return (
+      <div className="rounded-md border border-amber-500/60 bg-amber-500/10 p-4 text-sm text-amber-200">
+        Configure Supabase credentials to access analytics dashboards.
+      </div>
+    )
+  }
+
+  if (error) {
+    return <div className="rounded-md border border-rose-500/60 bg-rose-500/10 p-4 text-sm text-rose-200">{error}</div>
+  }
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-50">Commerce analytics</h1>
+        <p className="text-sm text-slate-400">Track performance, spot trends, and respond proactively.</p>
+      </header>
+
+      <section className="grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <p className="text-xs uppercase tracking-wide text-slate-500">Gross revenue (30d)</p>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">
+            {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(revenueTotal / 100)}
+          </p>
+        </div>
+        {Object.entries(revenue).map(([status, amount]) => (
+          <div key={status} className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+            <p className="text-xs uppercase tracking-wide text-slate-500">{status}</p>
+            <p className="mt-2 text-xl font-semibold text-slate-100">
+              {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(amount / 100)}
+            </p>
+          </div>
+        ))}
+      </section>
+
+      <section className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+        <h2 className="text-lg font-semibold text-slate-100">Daily sales (last 30 days)</h2>
+        {formattedDailySales.length === 0 ? (
+          <p className="mt-3 text-sm text-slate-400">No orders recorded in the selected range.</p>
+        ) : (
+          <ul className="mt-4 grid gap-2 sm:grid-cols-2 lg:grid-cols-3">
+            {formattedDailySales.map((entry) => (
+              <li key={entry.date} className="rounded-md border border-slate-800/60 bg-slate-900/40 px-4 py-3 text-sm text-slate-200">
+                <p className="text-xs uppercase tracking-wide text-slate-500">{entry.date}</p>
+                <p className="mt-1 text-base font-semibold text-slate-100">
+                  {new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(entry.total)}
+                </p>
+              </li>
+            ))}
+          </ul>
+        )}
+      </section>
+
+      <section className="grid gap-4 lg:grid-cols-2">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Recent inventory adjustments</h2>
+          <ul className="mt-3 space-y-2 text-sm text-slate-300">
+            {inventoryEvents.map((event) => (
+              <li key={event.id} className="rounded-md border border-slate-800/60 bg-slate-900/40 px-3 py-2">
+                <div className="flex items-center justify-between">
+                  <p className="font-semibold text-slate-100">{event.product_id.slice(0, 8)}…</p>
+                  <span className={`text-xs font-semibold ${event.quantity_delta >= 0 ? 'text-emerald-300' : 'text-rose-300'}`}>
+                    {event.quantity_delta >= 0 ? '+' : ''}
+                    {event.quantity_delta}
+                  </span>
+                </div>
+                <p className="text-xs text-slate-500">{new Date(event.created_at).toLocaleString()}</p>
+                <p className="text-xs text-slate-400">{event.reason ?? 'No reason provided'}</p>
+              </li>
+            ))}
+          </ul>
+        </div>
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Audit trail</h2>
+          <ul className="mt-3 space-y-2 text-sm text-slate-300">
+            {auditLog.map((entry) => (
+              <li key={entry.id} className="rounded-md border border-slate-800/60 bg-slate-900/40 px-3 py-2">
+                <p className="font-semibold text-slate-100">{entry.action}</p>
+                <p className="text-xs text-slate-500">{new Date(entry.created_at).toLocaleString()}</p>
+                <p className="text-xs text-slate-400">
+                  Target: {entry.target_table ?? '—'} {entry.target_id ? `(${entry.target_id.slice(0, 8)}…)` : ''}
+                </p>
+              </li>
+            ))}
+          </ul>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/admin/CatalogManagementPage.tsx
+++ b/src/pages/admin/CatalogManagementPage.tsx
@@ -1,0 +1,366 @@
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react'
+import { supabase } from '../../supabaseClient'
+
+interface AdminCategory {
+  id: string
+  name: string
+  slug: string
+  description?: string | null
+}
+
+interface AdminProduct {
+  id: string
+  name: string
+  slug: string
+  status: string
+  price_cents: number
+  currency: string
+  inventory_count: number
+  category_id: string | null
+  category?: AdminCategory | null
+}
+
+const currencyFormatter = new Intl.NumberFormat('en-US', {
+  style: 'currency',
+  currency: 'USD',
+})
+
+function slugify(input: string) {
+  return input
+    .trim()
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/(^-|-$)+/g, '')
+}
+
+export default function CatalogManagementPage() {
+  const [products, setProducts] = useState<AdminProduct[]>([])
+  const [categories, setCategories] = useState<AdminCategory[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [newCategoryName, setNewCategoryName] = useState('')
+  const [newCategoryDescription, setNewCategoryDescription] = useState('')
+
+  const client = supabase
+
+  const fetchCatalog = useCallback(async () => {
+    if (!client) {
+      setError('Supabase client is not configured')
+      setLoading(false)
+      return
+    }
+    setLoading(true)
+    setError(null)
+
+    const [{ data: productData, error: productError }, { data: categoryData, error: categoryError }] = await Promise.all([
+      client
+        .from('products')
+        .select(
+          'id, name, slug, status, price_cents, currency, inventory_count, category_id, categories:category_id (id, name, slug, description)',
+        )
+        .order('created_at', { ascending: false }),
+      client.from('categories').select('id, name, slug, description').order('position', { ascending: true }),
+    ])
+
+    if (productError || categoryError) {
+      setError(productError?.message ?? categoryError?.message ?? 'Unable to load catalog data')
+      setLoading(false)
+      return
+    }
+
+    setProducts(
+      (productData ?? []).map((product) => ({
+        id: product.id,
+        name: product.name,
+        slug: product.slug,
+        status: product.status,
+        price_cents: product.price_cents,
+        currency: product.currency,
+        inventory_count: product.inventory_count,
+        category_id: product.category_id,
+        category: product.categories
+          ? {
+              id: product.categories.id,
+              name: product.categories.name,
+              slug: product.categories.slug,
+              description: product.categories.description,
+            }
+          : null,
+      })),
+    )
+    setCategories((categoryData ?? []) as AdminCategory[])
+    setLoading(false)
+  }, [client])
+
+  useEffect(() => {
+    void fetchCatalog()
+  }, [fetchCatalog])
+
+  const handleInventoryAdjust = useCallback(
+    async (productId: string) => {
+      if (!client) {
+        setError('Supabase client is not configured')
+        return
+      }
+
+      const deltaInput = window.prompt('Adjustment amount (use negative numbers to deduct)', '1')
+      if (deltaInput === null) return
+
+      const delta = Number.parseInt(deltaInput, 10)
+      if (!Number.isFinite(delta) || Number.isNaN(delta)) {
+        setError('Please provide a valid number')
+        return
+      }
+
+      const confirmed = window.confirm(`Apply an adjustment of ${delta} units? This action will be logged.`)
+      if (!confirmed) return
+
+      const { data, error: rpcError } = await client.rpc('admin_adjust_inventory', {
+        p_product_id: productId,
+        p_quantity_delta: delta,
+        p_reason: 'Manual admin adjustment',
+        p_context: { source: 'admin-ui' },
+      })
+
+      if (rpcError) {
+        setError(rpcError.message)
+        setMessage(null)
+        return
+      }
+
+      if (!data) {
+        setError('Inventory update did not return a product record')
+        setMessage(null)
+        return
+      }
+
+      setError(null)
+      setProducts((current) => current.map((p) => (p.id === productId ? { ...p, inventory_count: data.inventory_count } : p)))
+      setMessage(`Inventory adjusted. New quantity: ${data.inventory_count}`)
+    },
+    [client],
+  )
+
+  const handleToggleStatus = useCallback(
+    async (product: AdminProduct) => {
+      if (!client) {
+        setError('Supabase client is not configured')
+        return
+      }
+
+      const nextStatus = product.status === 'active' ? 'draft' : 'active'
+      const confirmed = window.confirm(`Switch ${product.name} to ${nextStatus}?`)
+      if (!confirmed) return
+
+      const { error: updateError } = await client
+        .from('products')
+        .update({ status: nextStatus })
+        .eq('id', product.id)
+
+      if (updateError) {
+        setError(updateError.message)
+        setMessage(null)
+        return
+      }
+
+      setError(null)
+      setProducts((current) => current.map((p) => (p.id === product.id ? { ...p, status: nextStatus } : p)))
+      setMessage(`${product.name} is now ${nextStatus}`)
+    },
+    [client],
+  )
+
+  const handleCreateCategory = useCallback(
+    async (event: FormEvent<HTMLFormElement>) => {
+      event.preventDefault()
+      if (!client) {
+        setError('Supabase client is not configured')
+        return
+      }
+
+      const name = newCategoryName.trim()
+      if (!name) {
+        setError('Category name is required')
+        return
+      }
+
+      const slug = slugify(name)
+      const confirmed = window.confirm(`Create category “${name}”?`)
+      if (!confirmed) return
+
+      const { error: insertError } = await client.from('categories').insert({
+        name,
+        slug,
+        description: newCategoryDescription.trim() || null,
+      })
+
+      if (insertError) {
+        setError(insertError.message)
+        setMessage(null)
+        return
+      }
+
+      setError(null)
+      setNewCategoryName('')
+      setNewCategoryDescription('')
+      setMessage('Category created successfully')
+      await fetchCatalog()
+    },
+    [client, fetchCatalog, newCategoryDescription, newCategoryName],
+  )
+
+  const groupedProducts = useMemo(() => {
+    const grouped = new Map<string, AdminProduct[]>()
+    for (const product of products) {
+      const key = product.category?.name ?? 'Uncategorized'
+      const existing = grouped.get(key) ?? []
+      existing.push(product)
+      grouped.set(key, existing)
+    }
+    return Array.from(grouped.entries())
+  }, [products])
+
+  if (loading) {
+    return <div className="text-sm text-slate-300">Loading catalog...</div>
+  }
+
+  if (!client) {
+    return (
+      <div className="rounded-md border border-amber-500/60 bg-amber-500/10 p-4 text-sm text-amber-200">
+        Configure <code className="font-mono text-xs">VITE_SUPABASE_URL</code> and <code className="font-mono text-xs">VITE_SUPABASE_ANON_KEY</code> to enable
+        catalog management.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-50">Catalog management</h1>
+          <p className="text-sm text-slate-400">Track product health, adjust stock, and curate categories.</p>
+        </div>
+      </div>
+
+      {error ? (
+        <div className="rounded-md border border-rose-500/50 bg-rose-500/10 p-4 text-sm text-rose-200">{error}</div>
+      ) : null}
+      {message ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">{message}</div>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="space-y-4">
+          {groupedProducts.map(([groupName, groupProducts]) => (
+            <div key={groupName} className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+              <div className="flex items-center justify-between border-b border-slate-800/60 pb-2">
+                <h2 className="text-lg font-semibold text-slate-100">{groupName}</h2>
+                <span className="text-xs text-slate-400">{groupProducts.length} products</span>
+              </div>
+              <ul className="divide-y divide-slate-800/60">
+                {groupProducts.map((product) => (
+                  <li key={product.id} className="py-3">
+                    <div className="flex flex-col gap-2 md:flex-row md:items-center md:justify-between">
+                      <div>
+                        <p className="text-sm font-semibold text-slate-100">{product.name}</p>
+                        <p className="text-xs text-slate-500">{product.slug}</p>
+                        <p className="text-xs text-slate-400">
+                          {currencyFormatter.format(product.price_cents / 100)} • Inventory{' '}
+                          <span className={product.inventory_count === 0 ? 'text-rose-300' : 'text-emerald-300'}>
+                            {product.inventory_count}
+                          </span>
+                        </p>
+                      </div>
+                      <div className="flex items-center gap-2">
+                        <span
+                          className={`rounded-full px-3 py-1 text-xs font-semibold uppercase tracking-wide ${
+                            product.status === 'active'
+                              ? 'bg-emerald-500/10 text-emerald-200'
+                              : 'bg-slate-800/60 text-slate-300'
+                          }`}
+                        >
+                          {product.status}
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void handleInventoryAdjust(product.id)
+                          }}
+                          className="rounded-md border border-slate-700/70 px-3 py-1 text-xs font-medium text-slate-200 transition hover:border-emerald-500/50 hover:text-emerald-200"
+                        >
+                          Adjust stock
+                        </button>
+                        <button
+                          type="button"
+                          onClick={() => {
+                            void handleToggleStatus(product)
+                          }}
+                          className="rounded-md border border-slate-700/70 px-3 py-1 text-xs font-medium text-slate-200 transition hover:border-indigo-500/50 hover:text-indigo-200"
+                        >
+                          Toggle status
+                        </button>
+                      </div>
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <aside className="space-y-4">
+          <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+            <h2 className="text-lg font-semibold text-slate-100">Create category</h2>
+            <p className="mt-1 text-xs text-slate-400">New categories instantly sync to the storefront navigation.</p>
+            <form className="mt-4 space-y-3" onSubmit={handleCreateCategory}>
+              <div>
+                <label htmlFor="category-name" className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Name
+                </label>
+                <input
+                  id="category-name"
+                  value={newCategoryName}
+                  onChange={(event) => setNewCategoryName(event.target.value)}
+                  className="mt-1 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                  placeholder="Mindful Living"
+                />
+              </div>
+              <div>
+                <label htmlFor="category-description" className="text-xs font-semibold uppercase tracking-wide text-slate-400">
+                  Description
+                </label>
+                <textarea
+                  id="category-description"
+                  value={newCategoryDescription}
+                  onChange={(event) => setNewCategoryDescription(event.target.value)}
+                  className="mt-1 h-24 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                  placeholder="Optional summary displayed in admin tools"
+                />
+              </div>
+              <button
+                type="submit"
+                className="w-full rounded-md border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-500/20"
+              >
+                Create category
+              </button>
+            </form>
+          </div>
+          <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+            <h2 className="text-lg font-semibold text-slate-100">Existing categories</h2>
+            <ul className="mt-3 space-y-2 text-sm text-slate-300">
+              {categories.map((category) => (
+                <li key={category.id} className="flex items-center justify-between rounded-md border border-slate-800/70 px-3 py-2">
+                  <span>
+                    <p className="font-semibold text-slate-100">{category.name}</p>
+                    <p className="text-xs text-slate-500">{category.slug}</p>
+                  </span>
+                  <span className="text-xs text-slate-500">{category.description}</span>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </aside>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/admin/ContentManagementPage.tsx
+++ b/src/pages/admin/ContentManagementPage.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useMemo, useState, type FormEventHandler } from 'react'
+import { supabase } from '../../supabaseClient'
+
+interface SettingRecord {
+  key: string
+  value: Record<string, unknown>
+  description: string | null
+}
+
+interface MediaRecord {
+  id: string
+  product_id: string | null
+  path: string
+  media_type: string
+  alt_text: string | null
+  created_at: string
+}
+
+export default function ContentManagementPage() {
+  const client = supabase
+  const [settings, setSettings] = useState<SettingRecord[]>([])
+  const [selectedKey, setSelectedKey] = useState<string | null>(null)
+  const [settingDraft, setSettingDraft] = useState('')
+  const [mediaAssets, setMediaAssets] = useState<MediaRecord[]>([])
+  const [uploadProductId, setUploadProductId] = useState('')
+  const [uploadAltText, setUploadAltText] = useState('')
+  const [uploading, setUploading] = useState(false)
+  const [feedback, setFeedback] = useState<string | null>(null)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchContent = useCallback(async () => {
+    if (!client) {
+      setError('Supabase client is not configured')
+      return
+    }
+
+    const [{ data: settingsData, error: settingsError }, { data: mediaData, error: mediaError }] = await Promise.all([
+      client.from('settings').select('key, value, description').order('key', { ascending: true }),
+      client
+        .from('media')
+        .select('id, product_id, path, media_type, alt_text, created_at')
+        .order('created_at', { ascending: false })
+        .limit(10),
+    ])
+
+    if (settingsError || mediaError) {
+      setError(settingsError?.message ?? mediaError?.message ?? 'Unable to load content records')
+      return
+    }
+
+    setError(null)
+    setSettings((settingsData ?? []) as SettingRecord[])
+    setMediaAssets((mediaData ?? []) as MediaRecord[])
+    if (!selectedKey && settingsData && settingsData.length > 0) {
+      setSelectedKey(settingsData[0].key)
+      setSettingDraft(JSON.stringify(settingsData[0].value, null, 2))
+    }
+  }, [client, selectedKey])
+
+  useEffect(() => {
+    void fetchContent()
+  }, [fetchContent])
+
+  const selectedSetting = useMemo(() => settings.find((item) => item.key === selectedKey) ?? null, [selectedKey, settings])
+
+  useEffect(() => {
+    if (selectedSetting) {
+      setSettingDraft(JSON.stringify(selectedSetting.value, null, 2))
+    }
+  }, [selectedSetting])
+
+  const handleSettingSave = useCallback(async () => {
+    if (!client || !selectedKey) return
+    let payload: Record<string, unknown>
+    try {
+      payload = JSON.parse(settingDraft)
+    } catch (parseError) {
+      setError('Setting JSON is invalid')
+      return
+    }
+
+    setError(null)
+    const confirmed = window.confirm(`Update setting ${selectedKey}? This action impacts the storefront content.`)
+    if (!confirmed) return
+
+    const { error: updateError } = await client.from('settings').upsert({
+      key: selectedKey,
+      value: payload,
+      updated_at: new Date().toISOString(),
+    })
+
+    if (updateError) {
+      setError(updateError.message)
+      return
+    }
+
+    setFeedback('Setting saved successfully')
+    await fetchContent()
+  }, [client, fetchContent, selectedKey, settingDraft])
+
+  const handleUpload: FormEventHandler<HTMLFormElement> = useCallback(
+    async (event) => {
+      event.preventDefault()
+      if (!client) return
+
+      const input = event.currentTarget.elements.namedItem('media-file') as HTMLInputElement | null
+      const file = input?.files?.[0]
+      if (!file) {
+        setError('Select a file to upload')
+        return
+      }
+      if (!uploadProductId) {
+        setError('Provide a product ID to associate the media with')
+        return
+      }
+
+      const confirmed = window.confirm('Generate an upload URL and attach this asset to the catalog?')
+      if (!confirmed) return
+
+      setUploading(true)
+      setError(null)
+      setFeedback(null)
+
+      const { data, error: invokeError } = await client.functions.invoke('admin-upload-media', {
+        body: {
+          productId: uploadProductId,
+          fileName: file.name,
+          contentType: file.type || 'application/octet-stream',
+          altText: uploadAltText.trim() || null,
+        },
+      })
+
+      if (invokeError) {
+        setError(invokeError.message)
+        setUploading(false)
+        return
+      }
+
+      const uploadUrl = data?.uploadUrl as string | undefined
+      if (!uploadUrl) {
+        setError('Upload URL was not returned from the server')
+        setUploading(false)
+        return
+      }
+
+      const uploadResponse = await fetch(uploadUrl, {
+        method: 'PUT',
+        headers: { 'Content-Type': file.type || 'application/octet-stream' },
+        body: file,
+      })
+
+      if (!uploadResponse.ok) {
+        setError('File upload failed. Check Supabase storage configuration.')
+        setUploading(false)
+        return
+      }
+
+      setFeedback('Media asset uploaded and registered')
+      setUploading(false)
+      setUploadAltText('')
+      setUploadProductId('')
+      if (input) {
+        input.value = ''
+      }
+      await fetchContent()
+    },
+    [client, fetchContent, uploadAltText, uploadProductId],
+  )
+
+  if (!client) {
+    return (
+      <div className="rounded-md border border-amber-500/60 bg-amber-500/10 p-4 text-sm text-amber-200">
+        Configure Supabase credentials to manage content.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <header>
+        <h1 className="text-2xl font-semibold text-slate-50">Content & media</h1>
+        <p className="text-sm text-slate-400">Publish homepage copy, tweak merchandising blocks, and manage media assets.</p>
+      </header>
+
+      {error ? (
+        <div className="rounded-md border border-rose-500/60 bg-rose-500/10 p-4 text-sm text-rose-200">{error}</div>
+      ) : null}
+      {feedback ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">{feedback}</div>
+      ) : null}
+
+      <section className="grid gap-6 lg:grid-cols-[1fr,1fr]">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Storefront settings</h2>
+          <div className="mt-3 flex gap-3 text-sm">
+            <div className="w-48 space-y-2 text-slate-300">
+              {settings.map((setting) => (
+                <button
+                  key={setting.key}
+                  type="button"
+                  onClick={() => setSelectedKey(setting.key)}
+                  className={`w-full rounded-md border px-3 py-2 text-left text-xs transition ${
+                    selectedKey === setting.key
+                      ? 'border-emerald-500/70 bg-emerald-500/10 text-emerald-100'
+                      : 'border-slate-800/70 bg-slate-900/40 text-slate-300 hover:border-emerald-500/40'
+                  }`}
+                >
+                  <span className="font-semibold uppercase tracking-wide">{setting.key}</span>
+                  <p className="mt-1 text-[10px] text-slate-500">{setting.description ?? 'No description'}</p>
+                </button>
+              ))}
+            </div>
+            <div className="flex-1">
+              <label className="text-xs font-semibold uppercase tracking-wide text-slate-500">JSON payload</label>
+              <textarea
+                value={settingDraft}
+                onChange={(event) => setSettingDraft(event.target.value)}
+                className="mt-2 h-72 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 font-mono text-xs text-emerald-100 focus:border-emerald-500 focus:outline-none"
+              />
+              <button
+                type="button"
+                onClick={() => {
+                  void handleSettingSave()
+                }}
+                className="mt-3 rounded-md border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-500/20"
+              >
+                Save changes
+              </button>
+            </div>
+          </div>
+        </div>
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Upload media</h2>
+          <form className="mt-3 space-y-3" onSubmit={handleUpload}>
+            <div>
+              <label htmlFor="product-id" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Product ID
+              </label>
+              <input
+                id="product-id"
+                value={uploadProductId}
+                onChange={(event) => setUploadProductId(event.target.value)}
+                placeholder="00000000-0000-0000-0000-000000000101"
+                className="mt-1 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="alt-text" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Alt text
+              </label>
+              <input
+                id="alt-text"
+                value={uploadAltText}
+                onChange={(event) => setUploadAltText(event.target.value)}
+                placeholder="Lifestyle hero image"
+                className="mt-1 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+              />
+            </div>
+            <div>
+              <label htmlFor="media-file" className="text-xs font-semibold uppercase tracking-wide text-slate-500">
+                Asset file
+              </label>
+              <input
+                id="media-file"
+                name="media-file"
+                type="file"
+                className="mt-1 w-full text-sm text-slate-200"
+              />
+            </div>
+            <button
+              type="submit"
+              disabled={uploading}
+              className="rounded-md border border-emerald-500/60 bg-emerald-500/10 px-4 py-2 text-sm font-semibold text-emerald-200 transition hover:bg-emerald-500/20 disabled:cursor-not-allowed disabled:opacity-60"
+            >
+              {uploading ? 'Uploading…' : 'Generate upload URL'}
+            </button>
+          </form>
+          <div className="mt-6">
+            <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Recent assets</h3>
+            <ul className="mt-3 space-y-2 text-xs text-slate-300">
+              {mediaAssets.map((asset) => (
+                <li key={asset.id} className="rounded-md border border-slate-800/60 bg-slate-900/40 px-3 py-2">
+                  <p className="font-semibold text-slate-100">{asset.path}</p>
+                  <p className="text-[10px] text-slate-500">{new Date(asset.created_at).toLocaleString()}</p>
+                </li>
+              ))}
+            </ul>
+          </div>
+        </div>
+      </section>
+    </div>
+  )
+}

--- a/src/pages/admin/OrderFulfillmentPage.tsx
+++ b/src/pages/admin/OrderFulfillmentPage.tsx
@@ -1,0 +1,293 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { supabase } from '../../supabaseClient'
+
+interface AdminOrderSummary {
+  id: string
+  status: string
+  total_cents: number
+  currency: string
+  placed_at: string
+  fulfilled_at?: string | null
+  email: string | null
+  full_name: string | null
+  item_count: number
+}
+
+interface AdminOrderDetail {
+  id: string
+  status: string
+  total_cents: number
+  currency: string
+  shipping_address?: Record<string, unknown> | null
+  billing_address?: Record<string, unknown> | null
+  notes?: string | null
+  metadata?: Record<string, unknown> | null
+  customer_id: string
+  placed_at: string
+  fulfilled_at?: string | null
+  cancelled_at?: string | null
+  order_items: Array<{
+    id: number
+    quantity: number
+    unit_price_cents: number
+    subtotal_cents: number
+    product_id: string
+    products?: { name: string; slug: string }
+  }>
+}
+
+const statusOptions: Array<{ value: string; label: string }> = [
+  { value: 'pending', label: 'Pending' },
+  { value: 'processing', label: 'Processing' },
+  { value: 'fulfilled', label: 'Fulfilled' },
+  { value: 'cancelled', label: 'Cancelled' },
+  { value: 'refunded', label: 'Refunded' },
+]
+
+function formatCurrency(amount: number, currency: string) {
+  return new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency,
+  }).format(amount / 100)
+}
+
+export default function OrderFulfillmentPage() {
+  const client = supabase
+  const [orders, setOrders] = useState<AdminOrderSummary[]>([])
+  const [selectedOrder, setSelectedOrder] = useState<AdminOrderDetail | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+  const [message, setMessage] = useState<string | null>(null)
+  const [noteDraft, setNoteDraft] = useState('')
+
+  const fetchOrders = useCallback(async () => {
+    if (!client) {
+      setError('Supabase client is not configured')
+      setLoading(false)
+      return
+    }
+
+    setLoading(true)
+    setError(null)
+    const { data, error: queryError } = await client.from('admin_order_summary').select('*').order('placed_at', { ascending: false })
+
+    if (queryError) {
+      setError(queryError.message)
+      setLoading(false)
+      return
+    }
+
+    setOrders((data ?? []) as AdminOrderSummary[])
+    setLoading(false)
+  }, [client])
+
+  useEffect(() => {
+    void fetchOrders()
+  }, [fetchOrders])
+
+  const fetchOrderDetail = useCallback(
+    async (orderId: string) => {
+      if (!client) return
+      const { data, error: detailError } = await client
+        .from('orders')
+        .select('*, order_items(*, products:product_id(id, name, slug))')
+        .eq('id', orderId)
+        .maybeSingle()
+
+      if (detailError) {
+        setError(detailError.message)
+        return
+      }
+
+      if (data) {
+        setError(null)
+        setSelectedOrder({
+          ...(data as unknown as AdminOrderDetail),
+          order_items: (data.order_items ?? []).map((item) => ({
+            id: item.id,
+            quantity: item.quantity,
+            unit_price_cents: item.unit_price_cents,
+            subtotal_cents: item.subtotal_cents,
+            product_id: item.product_id,
+            products: item.products ? { name: item.products.name, slug: item.products.slug } : undefined,
+          })),
+        })
+      }
+    },
+    [client],
+  )
+
+  const handleSelectOrder = useCallback(
+    (order: AdminOrderSummary) => {
+      setSelectedOrder(null)
+      setMessage(null)
+      setNoteDraft('')
+      void fetchOrderDetail(order.id)
+    },
+    [fetchOrderDetail],
+  )
+
+  const handleStatusChange = useCallback(
+    async (orderId: string, nextStatus: string) => {
+      if (!client) return
+      const confirmed = window.confirm(`Move order ${orderId.slice(0, 8)}… to ${nextStatus}? This action will be audit logged.`)
+      if (!confirmed) return
+
+      const { data, error: rpcError } = await client.rpc('admin_update_order_status', {
+        p_order_id: orderId,
+        p_status: nextStatus,
+        p_notes: noteDraft.trim() || null,
+      })
+
+      if (rpcError) {
+        setError(rpcError.message)
+        setMessage(null)
+        return
+      }
+
+      setError(null)
+      setOrders((current) => current.map((order) => (order.id === orderId ? { ...order, status: nextStatus } : order)))
+      setMessage(`Order status updated to ${nextStatus}`)
+      if (selectedOrder && selectedOrder.id === orderId && data) {
+        setSelectedOrder({
+          ...selectedOrder,
+          status: data.status,
+          fulfilled_at: data.fulfilled_at,
+          cancelled_at: data.cancelled_at,
+          notes: data.notes ?? selectedOrder.notes,
+        })
+      }
+      setNoteDraft('')
+      await fetchOrders()
+    },
+    [client, fetchOrders, noteDraft, selectedOrder],
+  )
+
+  const totalRevenue = useMemo(() => orders.reduce((sum, order) => sum + order.total_cents, 0), [orders])
+  const openOrders = useMemo(() => orders.filter((order) => ['pending', 'processing'].includes(order.status)).length, [orders])
+
+  if (loading) {
+    return <div className="text-sm text-slate-300">Loading orders...</div>
+  }
+
+  if (!client) {
+    return (
+      <div className="rounded-md border border-amber-500/60 bg-amber-500/10 p-4 text-sm text-amber-200">
+        Configure Supabase credentials to manage orders.
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-slate-50">Order fulfillment</h1>
+          <p className="text-sm text-slate-400">Review incoming orders, update statuses, and coordinate logistics.</p>
+        </div>
+        <div className="flex gap-4 text-sm text-slate-300">
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Revenue (lifetime)</p>
+            <p className="text-base font-semibold text-emerald-300">{formatCurrency(totalRevenue, orders[0]?.currency ?? 'USD')}</p>
+          </div>
+          <div>
+            <p className="text-xs uppercase tracking-wide text-slate-500">Open orders</p>
+            <p className="text-base font-semibold text-slate-100">{openOrders}</p>
+          </div>
+        </div>
+      </header>
+
+      {error ? (
+        <div className="rounded-md border border-rose-500/50 bg-rose-500/10 p-4 text-sm text-rose-200">{error}</div>
+      ) : null}
+      {message ? (
+        <div className="rounded-md border border-emerald-500/40 bg-emerald-500/10 p-4 text-sm text-emerald-200">{message}</div>
+      ) : null}
+
+      <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
+        <div className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Recent orders</h2>
+          <div className="mt-4 space-y-3">
+            {orders.map((order) => (
+              <button
+                key={order.id}
+                type="button"
+                onClick={() => handleSelectOrder(order)}
+                className={`w-full rounded-lg border px-4 py-3 text-left text-sm transition ${
+                  selectedOrder?.id === order.id
+                    ? 'border-emerald-500/60 bg-emerald-500/10 text-emerald-100'
+                    : 'border-slate-800/70 bg-slate-950/40 text-slate-300 hover:border-emerald-500/40'
+                }`}
+              >
+                <div className="flex items-center justify-between">
+                  <p className="font-semibold text-slate-100">{order.full_name ?? order.email ?? 'Guest'}</p>
+                  <span className="text-xs text-slate-500">{new Date(order.placed_at).toLocaleString()}</span>
+                </div>
+                <div className="mt-1 flex items-center justify-between text-xs text-slate-400">
+                  <span>{order.item_count} items</span>
+                  <span>{formatCurrency(order.total_cents, order.currency)}</span>
+                </div>
+                <span className="mt-2 inline-block rounded-full bg-slate-800/70 px-3 py-1 text-xs uppercase tracking-wide text-slate-300">
+                  {order.status}
+                </span>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        <aside className="rounded-xl border border-slate-800/80 bg-slate-950/50 p-4">
+          <h2 className="text-lg font-semibold text-slate-100">Order detail</h2>
+          {selectedOrder ? (
+            <div className="mt-3 space-y-3 text-sm text-slate-300">
+              <div className="rounded-md border border-slate-800/60 bg-slate-900/60 p-3">
+                <p className="text-xs uppercase tracking-wide text-slate-500">Order ID</p>
+                <p className="font-mono text-sm">{selectedOrder.id}</p>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Status</p>
+                <select
+                  value={selectedOrder.status}
+                  onChange={(event) => {
+                    void handleStatusChange(selectedOrder.id, event.target.value)
+                  }}
+                  className="mt-1 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                >
+                  {statusOptions.map((option) => (
+                    <option key={option.value} value={option.value}>
+                      {option.label}
+                    </option>
+                  ))}
+                </select>
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Leave an internal note</p>
+                <textarea
+                  value={noteDraft}
+                  onChange={(event) => setNoteDraft(event.target.value)}
+                  placeholder="Shipping label printed, awaiting carrier pickup"
+                  className="mt-1 h-24 w-full rounded-md border border-slate-700/70 bg-slate-900 px-3 py-2 text-sm text-slate-100 focus:border-emerald-500 focus:outline-none"
+                />
+              </div>
+              <div>
+                <p className="text-xs uppercase tracking-wide text-slate-500">Items</p>
+                <ul className="mt-2 space-y-2">
+                  {selectedOrder.order_items.map((item) => (
+                    <li key={item.id} className="flex items-center justify-between rounded-md border border-slate-800/60 bg-slate-900/40 px-3 py-2">
+                      <div>
+                        <p className="font-semibold text-slate-100">{item.products?.name ?? 'Product removed'}</p>
+                        <p className="text-xs text-slate-500">{item.quantity} × {formatCurrency(item.unit_price_cents, selectedOrder.currency)}</p>
+                      </div>
+                      <p className="text-sm text-slate-200">{formatCurrency(item.subtotal_cents, selectedOrder.currency)}</p>
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            </div>
+          ) : (
+            <p className="mt-3 text-sm text-slate-400">Select an order to review fulfillment details.</p>
+          )}
+        </aside>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/admin/ProtectedAdminRoute.tsx
+++ b/src/pages/admin/ProtectedAdminRoute.tsx
@@ -1,0 +1,43 @@
+import type { ReactElement } from 'react'
+import { Navigate, useLocation } from 'react-router-dom'
+import { useAdminSession } from '../../hooks/useAdminSession'
+
+interface ProtectedAdminRouteProps {
+  children: ReactElement
+}
+
+export default function ProtectedAdminRoute({ children }: ProtectedAdminRouteProps) {
+  const { session, isAdmin, loading, error } = useAdminSession()
+  const location = useLocation()
+
+  if (loading) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="rounded-md bg-slate-900 px-4 py-3 text-sm text-slate-300 shadow-lg">
+          Checking admin permissions...
+        </div>
+      </div>
+    )
+  }
+
+  if (error) {
+    return (
+      <div className="flex h-full items-center justify-center">
+        <div className="max-w-sm rounded-md border border-red-500/50 bg-red-950/40 p-4 text-sm text-red-200">
+          <p className="font-semibold">Unable to verify permissions</p>
+          <p className="mt-1 text-red-300">{error}</p>
+        </div>
+      </div>
+    )
+  }
+
+  if (!session) {
+    return <Navigate to="/account" state={{ from: location.pathname }} replace />
+  }
+
+  if (!isAdmin) {
+    return <Navigate to="/" replace />
+  }
+
+  return children
+}

--- a/supabase/functions/admin-upload-media/index.ts
+++ b/supabase/functions/admin-upload-media/index.ts
@@ -1,0 +1,122 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.44.4'
+
+type UploadRequest = {
+  productId: string
+  fileName: string
+  contentType: string
+  bucket?: string
+  altText?: string | null
+  metadata?: Record<string, unknown>
+}
+
+type ErrorResponse = {
+  message: string
+  details?: unknown
+}
+
+const respond = (status: number, payload: Record<string, unknown> | ErrorResponse) =>
+  new Response(JSON.stringify(payload), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+
+Deno.serve(async (req) => {
+  if (req.method !== 'POST') {
+    return respond(405, { message: 'Method not allowed' })
+  }
+
+  const authHeader = req.headers.get('Authorization') ?? ''
+  const token = authHeader.replace('Bearer ', '').trim()
+
+  if (!token) {
+    return respond(401, { message: 'Missing Bearer token' })
+  }
+
+  let body: UploadRequest
+  try {
+    body = await req.json()
+  } catch (error) {
+    return respond(400, { message: 'Invalid JSON payload', details: error instanceof Error ? error.message : String(error) })
+  }
+
+  const supabaseUrl = Deno.env.get('SUPABASE_URL')
+  const serviceRoleKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')
+
+  if (!supabaseUrl || !serviceRoleKey) {
+    return respond(500, { message: 'Supabase credentials are not configured for the edge function' })
+  }
+
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+    global: {
+      headers: { Authorization: `Bearer ${token}` },
+    },
+  })
+
+  const { data: authResult, error: authError } = await supabase.auth.getUser(token)
+
+  if (authError || !authResult?.user) {
+    return respond(401, { message: 'Invalid or expired token', details: authError?.message })
+  }
+
+  const { user } = authResult
+
+  const { data: roleRecord, error: roleError } = await supabase
+    .from('app_user_roles')
+    .select('role')
+    .eq('user_id', user.id)
+    .maybeSingle()
+
+  if (roleError) {
+    return respond(500, { message: 'Unable to verify user role', details: roleError.message })
+  }
+
+  if (roleRecord?.role !== 'admin') {
+    return respond(403, { message: 'Only administrators can upload media' })
+  }
+
+  const bucket = body.bucket ?? 'product-assets'
+  const fileName = body.fileName.trim()
+  const productId = body.productId
+
+  if (!productId || !fileName) {
+    return respond(400, { message: 'productId and fileName are required' })
+  }
+
+  const safeFileName = fileName.replace(/[^A-Za-z0-9_.-]+/g, '-')
+  const filePath = `${productId}/${crypto.randomUUID()}-${safeFileName}`
+
+  const { data: signedUpload, error: uploadError } = await supabase.storage
+    .from(bucket)
+    .createSignedUploadUrl(filePath, {
+      contentType: body.contentType,
+      upsert: true,
+    })
+
+  if (uploadError || !signedUpload) {
+    return respond(500, { message: 'Unable to create upload URL', details: uploadError?.message })
+  }
+
+  const { data: mediaRecord, error: mediaError } = await supabase.rpc('admin_register_media_asset', {
+    p_product_id: productId,
+    p_bucket: bucket,
+    p_path: filePath,
+    p_media_type: body.contentType,
+    p_alt_text: body.altText,
+    p_metadata: body.metadata ?? {},
+  })
+
+  if (mediaError) {
+    return respond(500, { message: 'Unable to register media asset', details: mediaError.message })
+  }
+
+  return respond(200, {
+    uploadUrl: signedUpload.signedUrl,
+    token: signedUpload.token,
+    path: filePath,
+    media: mediaRecord,
+  })
+})

--- a/supabase/migrations/0001_ecommerce_schema.sql
+++ b/supabase/migrations/0001_ecommerce_schema.sql
@@ -1,0 +1,466 @@
+-- 0001_ecommerce_schema.sql
+-- Foundational schema for Evolvencia Solutions commerce experience
+
+-- Extensions -----------------------------------------------------------------
+create extension if not exists pgcrypto with schema public;
+create extension if not exists "uuid-ossp" with schema public;
+
+-- Utility tables and helpers --------------------------------------------------
+create table if not exists app_user_roles (
+  user_id uuid primary key references auth.users on delete cascade,
+  role text not null check (role in ('admin', 'customer')),
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+comment on table app_user_roles is 'Maps Supabase auth users to application roles used for authorization.';
+
+create or replace function public.is_admin()
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+select exists (
+  select 1
+  from app_user_roles r
+  where r.user_id = auth.uid()
+    and r.role = 'admin'
+);
+$$;
+
+comment on function public.is_admin is 'Returns true when the current authenticated user has the admin role.';
+
+create or replace function public.is_customer()
+returns boolean
+language sql
+security definer
+set search_path = public
+stable
+as $$
+select exists (
+  select 1
+  from app_user_roles r
+  where r.user_id = auth.uid()
+    and r.role in ('customer', 'admin')
+);
+$$;
+
+comment on function public.is_customer is 'Returns true when the current authenticated user is a customer (admins are also treated as customers).';
+
+-- Catalog ---------------------------------------------------------------------
+create table if not exists categories (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  description text,
+  position integer not null default 0,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists products (
+  id uuid primary key default gen_random_uuid(),
+  category_id uuid references categories(id) on delete set null,
+  name text not null,
+  slug text not null unique,
+  description text,
+  price_cents integer not null check (price_cents >= 0),
+  currency text not null default 'USD',
+  sku text,
+  status text not null default 'draft' check (status in ('draft', 'active', 'archived')),
+  inventory_count integer not null default 0 check (inventory_count >= 0),
+  attributes jsonb not null default '{}'::jsonb,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists media (
+  id uuid primary key default gen_random_uuid(),
+  product_id uuid references products(id) on delete cascade,
+  bucket text not null default 'product-assets',
+  path text not null,
+  media_type text not null,
+  alt_text text,
+  is_primary boolean not null default false,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists settings (
+  key text primary key,
+  value jsonb not null,
+  description text,
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+-- Customers & Orders ----------------------------------------------------------
+create table if not exists customers (
+  id uuid primary key references auth.users on delete cascade,
+  email text,
+  full_name text,
+  phone text,
+  marketing_consent boolean not null default false,
+  address jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now()),
+  updated_at timestamptz not null default timezone('utc', now())
+);
+
+create or replace function public.ensure_customer_profile()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+begin
+  insert into customers (id, email, full_name)
+  values (new.id, new.email, new.raw_user_meta_data ->> 'full_name')
+  on conflict (id) do update set email = excluded.email;
+  insert into app_user_roles (user_id, role)
+  values (new.id, 'customer')
+  on conflict (user_id) do nothing;
+  return new;
+end;
+$$;
+
+do $$
+begin
+  if not exists (
+    select 1 from pg_trigger where tgname = 'on_auth_user_created'
+  ) then
+    create trigger on_auth_user_created
+      after insert on auth.users
+      for each row execute function public.ensure_customer_profile();
+  end if;
+end $$;
+
+
+create table if not exists orders (
+  id uuid primary key default gen_random_uuid(),
+  customer_id uuid not null references customers(id) on delete restrict,
+  status text not null default 'pending' check (status in ('pending', 'processing', 'fulfilled', 'cancelled', 'refunded')),
+  total_cents integer not null default 0,
+  currency text not null default 'USD',
+  shipping_address jsonb,
+  billing_address jsonb,
+  notes text,
+  metadata jsonb not null default '{}'::jsonb,
+  placed_at timestamptz not null default timezone('utc', now()),
+  fulfilled_at timestamptz,
+  cancelled_at timestamptz
+);
+
+create table if not exists order_items (
+  id bigserial primary key,
+  order_id uuid not null references orders(id) on delete cascade,
+  product_id uuid not null references products(id) on delete restrict,
+  quantity integer not null check (quantity > 0),
+  unit_price_cents integer not null check (unit_price_cents >= 0),
+  subtotal_cents integer generated always as (quantity * unit_price_cents) stored,
+  metadata jsonb not null default '{}'::jsonb
+);
+
+create table if not exists inventory_events (
+  id uuid primary key default gen_random_uuid(),
+  product_id uuid not null references products(id) on delete cascade,
+  quantity_delta integer not null,
+  reason text,
+  context jsonb not null default '{}'::jsonb,
+  resulting_quantity integer not null,
+  acted_by uuid references auth.users,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+create table if not exists admin_audit_logs (
+  id bigserial primary key,
+  actor uuid references auth.users,
+  action text not null,
+  target_table text,
+  target_id uuid,
+  metadata jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default timezone('utc', now())
+);
+
+-- Row Level Security ----------------------------------------------------------
+alter table app_user_roles enable row level security;
+alter table categories enable row level security;
+alter table products enable row level security;
+alter table media enable row level security;
+alter table settings enable row level security;
+alter table customers enable row level security;
+alter table orders enable row level security;
+alter table order_items enable row level security;
+alter table inventory_events enable row level security;
+alter table admin_audit_logs enable row level security;
+
+-- app_user_roles policies
+create policy "Users can view own role" on app_user_roles
+  for select using (auth.uid() = user_id);
+
+create policy "Admins manage roles" on app_user_roles
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- categories policies
+create policy "Public categories read" on categories
+  for select using (true);
+
+create policy "Admin manage categories" on categories
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- products policies
+create policy "Public products read" on products
+  for select using (status = 'active' or public.is_admin());
+
+create policy "Admins manage products" on products
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- media policies
+create policy "Public media read" on media
+  for select using (true);
+
+create policy "Admins manage media" on media
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- settings policies
+create policy "Admins read settings" on settings
+  for select using (public.is_admin());
+
+create policy "Admins manage settings" on settings
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- customers policies
+create policy "Customer can view self" on customers
+  for select using (auth.uid() = id or public.is_admin());
+
+create policy "Customer can update self" on customers
+  for update using (auth.uid() = id)
+  with check (auth.uid() = id);
+
+create policy "Admins manage customers" on customers
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- orders policies
+create policy "Customer view own orders" on orders
+  for select using (auth.uid() = customer_id or public.is_admin());
+
+create policy "Customer manage own orders" on orders
+  for update using (auth.uid() = customer_id)
+  with check (auth.uid() = customer_id);
+
+create policy "Admins manage orders" on orders
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- order_items policies
+create policy "Customer view order items" on order_items
+  for select using (
+    exists (
+      select 1 from orders o
+      where o.id = order_items.order_id
+        and (o.customer_id = auth.uid() or public.is_admin())
+    )
+  );
+
+create policy "Admins manage order items" on order_items
+  using (public.is_admin())
+  with check (public.is_admin());
+
+-- inventory_events policies
+create policy "Admins read inventory events" on inventory_events
+  for select using (public.is_admin());
+
+create policy "Admins insert inventory events" on inventory_events
+  for insert with check (public.is_admin());
+
+-- admin_audit_logs policies
+create policy "Admins read audit logs" on admin_audit_logs
+  for select using (public.is_admin());
+
+create policy "Admins insert audit logs" on admin_audit_logs
+  for insert with check (public.is_admin());
+
+-- Functions / RPCs ------------------------------------------------------------
+create or replace function public.admin_adjust_inventory(
+  p_product_id uuid,
+  p_quantity_delta integer,
+  p_reason text default null,
+  p_context jsonb default '{}'::jsonb
+)
+returns products
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_product products;
+begin
+  if not public.is_admin() then
+    raise exception 'You must be an admin to adjust inventory';
+  end if;
+
+  update products
+     set inventory_count = greatest(0, inventory_count + p_quantity_delta),
+         updated_at = timezone('utc', now())
+   where id = p_product_id
+  returning * into v_product;
+
+  if not found then
+    raise exception 'Product not found: %', p_product_id;
+  end if;
+
+  insert into inventory_events (product_id, quantity_delta, reason, context, resulting_quantity, acted_by)
+  values (p_product_id, p_quantity_delta, p_reason, coalesce(p_context, '{}'::jsonb), v_product.inventory_count, auth.uid());
+
+  insert into admin_audit_logs (actor, action, target_table, target_id, metadata)
+  values (auth.uid(), 'inventory.adjust', 'products', p_product_id,
+          jsonb_build_object('delta', p_quantity_delta, 'reason', p_reason, 'context', coalesce(p_context, '{}'::jsonb)));
+
+  return v_product;
+end;
+$$;
+
+create or replace function public.admin_update_order_status(
+  p_order_id uuid,
+  p_status text,
+  p_notes text default null
+)
+returns orders
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_order orders;
+  v_now timestamptz := timezone('utc', now());
+begin
+  if not public.is_admin() then
+    raise exception 'You must be an admin to update orders';
+  end if;
+
+  if p_status not in ('pending', 'processing', 'fulfilled', 'cancelled', 'refunded') then
+    raise exception 'Invalid status value: %', p_status;
+  end if;
+
+  update orders
+     set status = p_status,
+         fulfilled_at = case when p_status = 'fulfilled' then v_now else fulfilled_at end,
+         cancelled_at = case when p_status = 'cancelled' then v_now else cancelled_at end,
+         notes = coalesce(p_notes, notes)
+   where id = p_order_id
+  returning * into v_order;
+
+  if not found then
+    raise exception 'Order not found: %', p_order_id;
+  end if;
+
+  insert into admin_audit_logs (actor, action, target_table, target_id, metadata)
+  values (auth.uid(), 'orders.status_change', 'orders', p_order_id,
+          jsonb_build_object('status', p_status, 'notes', p_notes));
+
+  return v_order;
+end;
+$$;
+
+create or replace function public.admin_register_media_asset(
+  p_product_id uuid,
+  p_bucket text,
+  p_path text,
+  p_media_type text,
+  p_alt_text text default null,
+  p_metadata jsonb default '{}'::jsonb
+)
+returns media
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_media media;
+begin
+  if not public.is_admin() then
+    raise exception 'You must be an admin to register media';
+  end if;
+
+  insert into media (product_id, bucket, path, media_type, alt_text, metadata, is_primary)
+  values (p_product_id, p_bucket, p_path, p_media_type, p_alt_text, coalesce(p_metadata, '{}'::jsonb), false)
+  returning * into v_media;
+
+  insert into admin_audit_logs (actor, action, target_table, target_id, metadata)
+  values (auth.uid(), 'media.register', 'media', v_media.id,
+          jsonb_build_object('product_id', p_product_id, 'path', p_path, 'bucket', p_bucket));
+
+  return v_media;
+end;
+$$;
+
+-- Views -----------------------------------------------------------------------
+create or replace view admin_order_summary as
+select
+  o.id,
+  o.status,
+  o.total_cents,
+  o.currency,
+  o.placed_at,
+  o.fulfilled_at,
+  c.email,
+  c.full_name,
+  count(oi.id) as item_count
+from orders o
+join customers c on c.id = o.customer_id
+left join order_items oi on oi.order_id = o.id
+group by o.id, c.email, c.full_name;
+
+grants ------------------------------------------------------------------------
+grant usage on schema public to authenticated, anon;
+
+grant select on admin_order_summary to authenticated;
+
+-- Trigger helpers -------------------------------------------------------------
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = timezone('utc', now());
+  return new;
+end;
+$$;
+
+do $$ begin
+  if not exists (
+    select 1 from pg_trigger where tgname = 'set_timestamp_categories'
+  ) then
+    create trigger set_timestamp_categories
+      before update on categories
+      for each row execute function public.set_updated_at();
+  end if;
+  if not exists (
+    select 1 from pg_trigger where tgname = 'set_timestamp_products'
+  ) then
+    create trigger set_timestamp_products
+      before update on products
+      for each row execute function public.set_updated_at();
+  end if;
+  if not exists (
+    select 1 from pg_trigger where tgname = 'set_timestamp_customers'
+  ) then
+    create trigger set_timestamp_customers
+      before update on customers
+      for each row execute function public.set_updated_at();
+  end if;
+  if not exists (
+    select 1 from pg_trigger where tgname = 'set_timestamp_settings'
+  ) then
+    create trigger set_timestamp_settings
+      before update on settings
+      for each row execute function public.set_updated_at();
+  end if;
+end $$;
+

--- a/supabase/seeds/demo_seed.sql
+++ b/supabase/seeds/demo_seed.sql
@@ -1,0 +1,26 @@
+-- demo_seed.sql
+-- Populates the Evolvencia Solutions schema with sample data for local testing.
+
+insert into categories (id, name, slug, description, position)
+values
+  ('00000000-0000-0000-0000-000000000001', 'Wellness', 'wellness', 'Self-care essentials', 1),
+  ('00000000-0000-0000-0000-000000000002', 'Home Office', 'home-office', 'Stylish productivity upgrades', 2)
+on conflict (id) do nothing;
+
+insert into products (id, category_id, name, slug, description, price_cents, currency, sku, status, inventory_count, attributes)
+values
+  ('00000000-0000-0000-0000-000000000101', '00000000-0000-0000-0000-000000000001', 'Aromatherapy Diffuser', 'aromatherapy-diffuser', 'Mood lighting diffuser with essential oil kit.', 8900, 'USD', 'AROMA-01', 'active', 120, '{"size": "Medium", "color": "Soft White"}'::jsonb),
+  ('00000000-0000-0000-0000-000000000102', '00000000-0000-0000-0000-000000000002', 'Ergonomic Desk Mat', 'ergonomic-desk-mat', 'Supports wrists during long sessions.', 4500, 'USD', 'DESKMAT-01', 'active', 75, '{"material": "Vegan leather"}'::jsonb)
+on conflict (id) do nothing;
+
+insert into settings (key, value, description)
+values
+  ('storefront.hero', '{"headline": "Refresh your daily rituals", "subheading": "Limited spring edition"}', 'Homepage hero block copy'),
+  ('storefront.support_email', '{"address": "support@evolvencia.test"}', 'Primary support channel')
+on conflict (key) do update set value = excluded.value, description = excluded.description;
+
+-- Inventory snapshots for seeded products
+insert into inventory_events (id, product_id, quantity_delta, reason, context, resulting_quantity, acted_by)
+values
+  (gen_random_uuid(), '00000000-0000-0000-0000-000000000101', 120, 'Initial stock', '{"seed": true}'::jsonb, 120, null),
+  (gen_random_uuid(), '00000000-0000-0000-0000-000000000102', 75, 'Initial stock', '{"seed": true}'::jsonb, 75, null);


### PR DESCRIPTION
## Summary
- add Supabase migration covering catalog, customer, order, settings, and audit tables with admin/customer RLS and RPC helpers
- create an admin edge function plus seed data for media uploads and demo content
- build protected admin React routes for catalog, fulfillment, analytics, and content workflows with Supabase RPC/edge integrations and document setup steps

## Testing
- `npm install` *(fails: 403 Forbidden when requesting packages from registry)*

------
https://chatgpt.com/codex/tasks/task_e_68cee76dd54083309693e76fb92be26a